### PR TITLE
Update about.tsx

### DIFF
--- a/ts-router/src/pages/about.tsx
+++ b/ts-router/src/pages/about.tsx
@@ -1,15 +1,20 @@
 import { Suspense } from "solid-js";
+import { useData } from "solid-app-router";
 
-export default function About(props) {
+export default function About() {
+  const data = useData();
+  
   return (
     <section class="bg-pink-100 text-gray-700 p-8">
       <h1 class="text-2xl font-bold">About</h1>
 
       <p class="mt-4">A page all about this website.</p>
-
-      <pre class="mt-4">
-        <code>{JSON.stringify(props, null, 2)}</code>
-      </pre>
+      
+      <Suspense>
+        <pre class="mt-4">
+          <code>{JSON.stringify(data, null, 2)}</code>
+        </pre>
+      </Suspense>
     </section>
   );
 }


### PR DESCRIPTION
It looks like the data is not passed through props any longer (?) and the example on the solid-app-router page uses this 'useData' hook to get the data passed in from the route definition.