### PR TITLE
📝 Update the `pnpm` links in all the README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You get:
 
 ## Get started
 
-Those templates dependencies are maintained via [pnpm](https://pnpm.js.org/) via `pnpm up -Lri`.
+Those templates dependencies are maintained via [pnpm](https://pnpm.io) via `pnpm up -Lri`.
 
 This is the reason you see a `pnpm-lock.yaml`. That being said, any package manager will work. This file can be safely be removed once you clone a template.
 
@@ -68,7 +68,7 @@ Feel free to make a pull request. Copy on of the template already available, twe
 
 ## Contributing
 
-This project is managed with [pnpm](https://pnpm.js.org/). You should [install it](https://pnpm.js.org/install) first to test out your template or contribute to an existing one. 
+This project is managed with [pnpm](https://pnpm.io). You should [install it](https://pnpm.io/installation) first to test out your template or contribute to an existing one. 
 
 You can create your own template and prefix it with `ts-` or `js-` and giving it a name that describe the purpose.
 

--- a/js/README.md
+++ b/js/README.md
@@ -1,6 +1,6 @@
 ## Usage
 
-Those templates dependencies are maintained via [pnpm](https://pnpm.js.org/) via `pnpm up -Lri`.
+Those templates dependencies are maintained via [pnpm](https://pnpm.io) via `pnpm up -Lri`.
 
 This is the reason you see a `pnpm-lock.yaml`. That being said, any package manager will work. This file can be safely be removed once you clone a template.
 

--- a/ts-bootstrap/README.md
+++ b/ts-bootstrap/README.md
@@ -1,6 +1,6 @@
 ## Usage
 
-Those templates dependencies are maintained via [pnpm](https://pnpm.js.org/) via `pnpm up -Lri`.
+Those templates dependencies are maintained via [pnpm](https://pnpm.io) via `pnpm up -Lri`.
 
 This is the reason you see a `pnpm-lock.yaml`. That being said, any package manager will work. This file can be safely be removed once you clone a template.
 

--- a/ts-minimal/README.md
+++ b/ts-minimal/README.md
@@ -1,6 +1,6 @@
 ## Usage
 
-Those templates dependencies are maintained via [pnpm](https://pnpm.js.org/) via `pnpm up -Lri`.
+Those templates dependencies are maintained via [pnpm](https://pnpm.io) via `pnpm up -Lri`.
 
 This is the reason you see a `pnpm-lock.yaml`. That being said, any package manager will work. This file can be safely be removed once you clone a template.
 

--- a/ts-router/README.md
+++ b/ts-router/README.md
@@ -1,6 +1,6 @@
 ## Usage
 
-Those templates dependencies are maintained via [pnpm](https://pnpm.js.org/) via `pnpm up -Lri`.
+Those templates dependencies are maintained via [pnpm](https://pnpm.io) via `pnpm up -Lri`.
 
 This is the reason you see a `pnpm-lock.yaml`. That being said, any package manager will work. This file can be safely be removed once you clone a template.
 

--- a/ts-windicss/README.md
+++ b/ts-windicss/README.md
@@ -1,6 +1,6 @@
 ## Usage
 
-Those templates dependencies are maintained via [pnpm](https://pnpm.js.org/) via `pnpm up -Lri`.
+Those templates dependencies are maintained via [pnpm](https://pnpm.io) via `pnpm up -Lri`.
 
 This is the reason you see a `pnpm-lock.yaml`. That being said, any package manager will work. This file can be safely be removed once you clone a template.
 

--- a/ts/README.md
+++ b/ts/README.md
@@ -1,6 +1,6 @@
 ## Usage
 
-Those templates dependencies are maintained via [pnpm](https://pnpm.js.org/) via `pnpm up -Lri`.
+Those templates dependencies are maintained via [pnpm](https://pnpm.io) via `pnpm up -Lri`.
 
 This is the reason you see a `pnpm-lock.yaml`. That being said, any package manager will work. This file can be safely be removed once you clone a template.
 


### PR DESCRIPTION
- Changed `https://pnpm.js.org/` to `https://pnpm.io`  
- Fixed the [link for the page](https://pnpm.io/installation) with the installation instructions for `pnpm` 