### PR TITLE
fix: type cast root element as HTMLDivElement

### DIFF
--- a/ts-bootstrap/src/index.tsx
+++ b/ts-bootstrap/src/index.tsx
@@ -10,4 +10,4 @@ import "./cheatsheet.scss";
 
 import App from "./App";
 
-render(() => <App />, document.getElementById("root") as HTMLDivElement);
+render(() => <App />, document.getElementById("root") as HTMLElement);

--- a/ts-bootstrap/src/index.tsx
+++ b/ts-bootstrap/src/index.tsx
@@ -10,4 +10,4 @@ import "./cheatsheet.scss";
 
 import App from "./App";
 
-render(() => <App />, document.getElementById("root"));
+render(() => <App />, document.getElementById("root") as HTMLDivElement);

--- a/ts-minimal/src/index.tsx
+++ b/ts-minimal/src/index.tsx
@@ -2,5 +2,5 @@ import { render } from "solid-js/web";
 
 import App from "./App";
 
-render(() => <App />, document.getElementById("root") as HTMLDivElement);
+render(() => <App />, document.getElementById("root") as HTMLElement);
 

--- a/ts-minimal/src/index.tsx
+++ b/ts-minimal/src/index.tsx
@@ -2,5 +2,5 @@ import { render } from "solid-js/web";
 
 import App from "./App";
 
-render(() => <App />, document.getElementById("root"));
+render(() => <App />, document.getElementById("root") as HTMLDivElement);
 

--- a/ts-router/src/index.tsx
+++ b/ts-router/src/index.tsx
@@ -10,5 +10,5 @@ render(
       <App />
     </Router>
   ),
-  document.getElementById("root") as HTMLDivElement
+  document.getElementById("root") as HTMLElement
 );

--- a/ts-router/src/index.tsx
+++ b/ts-router/src/index.tsx
@@ -10,5 +10,5 @@ render(
       <App />
     </Router>
   ),
-  document.getElementById("root")
+  document.getElementById("root") as HTMLDivElement
 );

--- a/ts-windicss/src/index.tsx
+++ b/ts-windicss/src/index.tsx
@@ -3,4 +3,4 @@ import { render } from "solid-js/web";
 
 import App from "./App";
 
-render(() => <App />, document.getElementById("root"));
+render(() => <App />, document.getElementById("root") as HTMLDivElement);

--- a/ts-windicss/src/index.tsx
+++ b/ts-windicss/src/index.tsx
@@ -3,4 +3,4 @@ import { render } from "solid-js/web";
 
 import App from "./App";
 
-render(() => <App />, document.getElementById("root") as HTMLDivElement);
+render(() => <App />, document.getElementById("root") as HTMLElement);

--- a/ts/src/index.tsx
+++ b/ts/src/index.tsx
@@ -3,4 +3,4 @@ import { render } from "solid-js/web";
 import "./index.css";
 import App from "./App";
 
-render(() => <App />, document.getElementById("root"));
+render(() => <App />, document.getElementById("root") as HTMLDivElement);

--- a/ts/src/index.tsx
+++ b/ts/src/index.tsx
@@ -3,4 +3,4 @@ import { render } from "solid-js/web";
 import "./index.css";
 import App from "./App";
 
-render(() => <App />, document.getElementById("root") as HTMLDivElement);
+render(() => <App />, document.getElementById("root") as HTMLElement);


### PR DESCRIPTION
With the current typescript config settings, upon npm/yarn install users will get the ts error in edior

```typescript

Argument of type 'HTMLElement | null' is not assignable to parameter of type 'MountableElement'.
  Type 'null' is not assignable to type 'MountableElement'.ts(2345)

```

simple fix for this is to cast the type of 'root' as HTMLDivElement.