### PR TITLE
minor consistency fixes

### DIFF
--- a/ts-bootstrap/tsconfig.json
+++ b/ts-bootstrap/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": true,
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "node",

--- a/ts-minimal/tsconfig.json
+++ b/ts-minimal/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": true,
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "node",

--- a/ts-router/tsconfig.json
+++ b/ts-router/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": true,
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "node",

--- a/ts-windicss/tsconfig.json
+++ b/ts-windicss/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": true,
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "node",

--- a/ts/package.json
+++ b/ts/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.0",
   "description": "",
   "scripts": {
-    "start": "vite",
     "dev": "vite",
     "build": "vite build",
     "serve": "vite preview"


### PR DESCRIPTION
Makes [this PR](https://github.com/solidjs/templates/pull/11) apply to each template.

Removes `"start": "vite"` because no other template uses it. I'm a noob and have no idea if `start` or `dev` is preferred. If a better fix would be to _add_ `start` to each template, LMK!