### PR TITLE
add do not emit to tsconfig.json

### DIFF
--- a/ts-windicss/tsconfig.json
+++ b/ts-windicss/tsconfig.json
@@ -7,6 +7,7 @@
     "esModuleInterop": true,
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
-    "types": ["vite/client"]
+    "types": ["vite/client"],
+    "noEmit": true
   }
 }


### PR DESCRIPTION
Typescript should not be compiling the files, since vite is being used for that.