### PR TITLE
fix: update vite config on templates using vitest

### DIFF
--- a/js-vitest/vite.config.js
+++ b/js-vitest/vite.config.js
@@ -12,7 +12,7 @@ export default defineConfig({
     // solid needs to be inline to work around
     // a resolution issue in vitest:
     deps: {
-      inline: [/solid-js/],
+      inline: [/solid-js/, /solid-testing-library/],
     },
     // if you have few tests, try commenting one
     // or both out to improve performance:

--- a/ts-vitest/vite.config.ts
+++ b/ts-vitest/vite.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     // solid needs to be inline to work around
     // a resolution issue in vitest:
     deps: {
-      inline: [/solid-js/],
+      inline: [/solid-js/, 'solid-testing-library'],
     },
     // if you have few tests, try commenting one
     // or both out to improve performance:


### PR DESCRIPTION
Fixes https://github.com/solidjs/templates/issues/47

`solid-testing-library` ships has both esm and cjs modules, and the vite resolution does not seem to process it correctly. Explicitly declaring this dependency as an [inline dependency ](https://vitest.dev/config/#deps-inline) for vitest solves the issue.

Before:
<img width="661" alt="Screen Shot 2022-06-12 at 8 45 04 PM" src="https://user-images.githubusercontent.com/36057168/173261006-1c4af9f6-b656-4a73-9eaf-bb1ca275fbb8.png">

After:
<img width="489" alt="Screen Shot 2022-06-12 at 8 45 39 PM" src="https://user-images.githubusercontent.com/36057168/173261015-024c7e55-e66d-4a8e-a5b9-d54fd781693f.png">


