### PR TITLE
Add missing type assertion

### DIFF
--- a/ts-jest/src/index.tsx
+++ b/ts-jest/src/index.tsx
@@ -2,4 +2,4 @@ import { render } from 'solid-js/web';
 
 import { TodoList } from './todo-list';
 
-render(() => <TodoList />, document.getElementById('root'));
+render(() => <TodoList />, document.getElementById('root') as HTMLElement);

--- a/ts-uvu/src/index.tsx
+++ b/ts-uvu/src/index.tsx
@@ -2,4 +2,4 @@ import { render } from 'solid-js/web';
 
 import { TodoList } from './todo-list';
 
-render(() => <TodoList />, document.getElementById('root'));
+render(() => <TodoList />, document.getElementById('root') as HTMLElement);

--- a/ts-vitest/src/index.tsx
+++ b/ts-vitest/src/index.tsx
@@ -2,4 +2,4 @@ import { render } from 'solid-js/web';
 
 import { TodoList } from './todo-list';
 
-render(() => <TodoList />, document.getElementById('root'));
+render(() => <TodoList />, document.getElementById('root') as HTMLElement);


### PR DESCRIPTION
Without this type assertion, TypeScript generates the error:
> type null is not assignable to type MountableElement