### PR TITLE
js/vite.config.js: more opinionated config

### DIFF
--- a/js/vite.config.js
+++ b/js/vite.config.js
@@ -1,12 +1,48 @@
 import { defineConfig } from 'vite';
 import solidPlugin from 'vite-plugin-solid';
 
+const assetsDir = '';
+//const assetsDir = 'assets/';
+
+const outputDefaults = {
+  //format: 'iife', // default
+
+  // remove hashes from filenames
+  entryFileNames: `${assetsDir}[name].js`,
+  chunkFileNames: `${assetsDir}[name].js`,
+  assetFileNames: `${assetsDir}[name].[ext]`,
+}
+
 export default defineConfig({
-  plugins: [solidPlugin()],
+  root: "demo",
+  base: "./", // generate relative paths in html
+  plugins: [
+    solidPlugin(),
+  ],
   server: {
-    port: 3000,
+    //host: 'localhost',
+    //port: 3000,
   },
   build: {
     target: 'esnext',
+    polyfillDynamicImport: false,
+    //sourcemap: true,
+    minify: false, // smaller git diffs
+    // example sizes for solidjs app with monaco-editor
+    // false: 5396.78 KiB // smaller git diffs
+    // 'esbuild': 2027.36 KiB // default
+    // 'terser': 2002.37 KiB
+    rollupOptions: {
+      output: {
+        ...outputDefaults,
+      }
+    },
+  },
+  worker: {
+    rollupOptions: {
+      output: {
+        ...outputDefaults,
+      }
+    },
   },
 });


### PR DESCRIPTION
this is my `vite.config.js` for deploying demos to github pages

"keep it simple" is fine, but the current `vite.config.js` is too simple

also the `dev` command should be `vite --clearScreen false`
clearing terminal history is bad, mmkay?
