### PR TITLE
Add jsconfig file to js templates

### DIFF
--- a/js-vitest/jsconfig.json
+++ b/js-vitest/jsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js",
+    "types": ["vite/client"],
+    "noEmit": true,
+    "isolatedModules": true
+  }
+}

--- a/js/jsconfig.json
+++ b/js/jsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js",
+    "types": ["vite/client"],
+    "noEmit": true,
+    "isolatedModules": true
+  }
+}


### PR DESCRIPTION
I copied the `compilerOptions` from the `tsconfig` in the TS templates. Not sure if that is optimal, but it seems to fix the errors in VS Code.

Closes https://github.com/solidjs/templates/issues/72