### PR TITLE
feat: added `base: './'` to vite.config.ts

### DIFF
--- a/ts-bootstrap/vite.config.ts
+++ b/ts-bootstrap/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import solidPlugin from 'vite-plugin-solid';
 
 export default defineConfig({
+  base: './',
   plugins: [solidPlugin()],
   server: {
     port: 3000,

--- a/ts-jest/vite.config.ts
+++ b/ts-jest/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import solidPlugin from 'vite-plugin-solid';
 
 export default defineConfig({
+  base: './',
   plugins: [solidPlugin()],
   server: {
     port: 3000,

--- a/ts-minimal/vite.config.ts
+++ b/ts-minimal/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import solidPlugin from 'vite-plugin-solid';
 
 export default defineConfig({
+  base: './',
   plugins: [solidPlugin()],
   server: {
     port: 3000,

--- a/ts-router/vite.config.ts
+++ b/ts-router/vite.config.ts
@@ -3,6 +3,7 @@ import solidPlugin from 'vite-plugin-solid';
 import WindiCSS from 'vite-plugin-windicss';
 
 export default defineConfig({
+  base: './',
   plugins: [solidPlugin(), WindiCSS()],
   server: {
     port: 3000,

--- a/ts-sass/vite.config.ts
+++ b/ts-sass/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import solidPlugin from 'vite-plugin-solid';
 
 export default defineConfig({
+  base: './',
   plugins: [solidPlugin()],
   server: {
     port: 3000,

--- a/ts-tailwindcss/vite.config.ts
+++ b/ts-tailwindcss/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import solidPlugin from 'vite-plugin-solid';
 
 export default defineConfig({
+  base: './',
   plugins: [solidPlugin()],
   server: {
     port: 3000,

--- a/ts-unocss/vite.config.ts
+++ b/ts-unocss/vite.config.ts
@@ -3,6 +3,7 @@ import solidPlugin from 'vite-plugin-solid';
 import UnocssPlugin from '@unocss/vite';
 
 export default defineConfig({
+  base: './',
   plugins: [
     solidPlugin(),
     UnocssPlugin({

--- a/ts-uvu/vite.config.ts
+++ b/ts-uvu/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import solidPlugin from 'vite-plugin-solid';
 
 export default defineConfig({
+  base: './',
   plugins: [solidPlugin()],
   server: {
     port: 3000,

--- a/ts-vitest/vite.config.ts
+++ b/ts-vitest/vite.config.ts
@@ -5,6 +5,7 @@ import { defineConfig } from 'vite';
 import solidPlugin from 'vite-plugin-solid';
 
 export default defineConfig({
+  base: './',
   plugins: [solidPlugin()],
   server: {
     port: 3000,

--- a/ts-windicss/vite.config.ts
+++ b/ts-windicss/vite.config.ts
@@ -3,6 +3,7 @@ import solidPlugin from 'vite-plugin-solid';
 import WindiCSS from 'vite-plugin-windicss';
 
 export default defineConfig({
+  base: './',
   plugins: [
     solidPlugin(),
     WindiCSS({

--- a/ts/vite.config.ts
+++ b/ts/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import solidPlugin from 'vite-plugin-solid';
 
 export default defineConfig({
+  base: './',
   plugins: [solidPlugin()],
   server: {
     port: 3000,


### PR DESCRIPTION
I keep on forgetting this property and it's a difficult one to look-up online, so decided to put it into a PR. 

When deploying a site to a sub-directory, `base: './'`makes all the references point to the sub-directory instead of to the root. Handy for example when deploying to Github Pages: your script-link will instead of `bigmistqke.github.com/example` refer to `bigmistqke.github.com/`leading to a 404. 