### PR TITLE
Corrected spelling: "mispelled" -> "misspelled"

### DIFF
--- a/ts/src/index.tsx
+++ b/ts/src/index.tsx
@@ -8,7 +8,7 @@ const root = document.getElementById('root');
 
 if (import.meta.env.DEV && !(root instanceof HTMLElement)) {
   throw new Error(
-    'Root element not found. Did you forget to add it to your index.html? Or maybe the id attribute got mispelled?',
+    'Root element not found. Did you forget to add it to your index.html? Or maybe the id attribute got misspelled?',
   );
 }
 


### PR DESCRIPTION
Oh, the irony. 😉 