### PR TITLE
Fixed vitest templates

### DIFF
--- a/js-vitest/vite.config.js
+++ b/js-vitest/vite.config.js
@@ -10,8 +10,7 @@ export default defineConfig({
       web: [/\.jsx?$/],
     },
     setupFiles: ['node_modules/@testing-library/jest-dom/extend-expect.js'],
-    // otherwise, solid would be loaded twice:
-    deps: { registerNodeLoader: true },
+    deps: { registerNodeLoader: false },
     // if you have few tests, try commenting one
     // or both out to improve performance:
     // threads: false,

--- a/ts-vitest/vite.config.ts
+++ b/ts-vitest/vite.config.ts
@@ -22,8 +22,7 @@ export default defineConfig({
     globals: true,
     transformMode: { web: [/\.[jt]sx?$/] },
     setupFiles: ['node_modules/@testing-library/jest-dom/extend-expect.js'],
-    // otherwise, solid would be loaded twice:
-    deps: { registerNodeLoader: true },
+    deps: { registerNodeLoader: false },
     // if you have few tests, try commenting one
     // or both out to improve performance:
     threads: false,


### PR DESCRIPTION
'registerNodeLoader' on true wouldn't let the tests run successfully, not in this version, nor in newer. It also is necessary to have it explicitly on false, or else, the tests wouldn't work either.

Besides it doesn't log any warning on dependency duplicity, like it does in other cases, so I also removed the comments that said that.