### PR TITLE
fix: ts-unocss-shortcuts-invalid

### DIFF
--- a/ts-unocss/vite.config.ts
+++ b/ts-unocss/vite.config.ts
@@ -10,10 +10,10 @@ export default defineConfig({
     For more info see https://github.com/thetarnav/solid-devtools/tree/main/packages/extension#readme
     */
     // devtools(),
-    solidPlugin(),
     UnocssPlugin({
       // your config or in uno.config.ts
     }),
+    solidPlugin(),
   ],
   server: {
     port: 3000,


### PR DESCRIPTION
The order of UnocssPlugin and solidPlugin affects some functions of unocss
[https://github.com/solidjs/solid/issues/1449](https://github.com/solidjs/solid/issues/1449)