### PR TITLE
Modernize TSConfig

### DIFF
--- a/ts-bootstrap/package.json
+++ b/ts-bootstrap/package.json
@@ -11,6 +11,7 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "@types/bootstrap": "^5.2.10",
     "sass": "^1.81.0",
     "typescript": "^5.7.2",
     "vite": "^6.0.0",

--- a/ts-bootstrap/pnpm-lock.yaml
+++ b/ts-bootstrap/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
         specifier: ^1.9.3
         version: 1.9.3
     devDependencies:
+      '@types/bootstrap':
+        specifier: ^5.2.10
+        version: 5.2.10
       sass:
         specifier: ^1.81.0
         version: 1.81.0
@@ -29,7 +32,7 @@ importers:
         version: 6.0.0(sass@1.81.0)
       vite-plugin-solid:
         specifier: ^2.11.0
-        version: 2.11.0(solid-js@1.9.3)(vite@6.0.0)
+        version: 2.11.0(solid-js@1.9.3)(vite@6.0.0(sass@1.81.0))
 
 packages:
 
@@ -462,6 +465,9 @@ packages:
 
   '@types/babel__traverse@7.20.6':
     resolution: {integrity: sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==}
+
+  '@types/bootstrap@5.2.10':
+    resolution: {integrity: sha512-F2X+cd6551tep0MvVZ6nM8v7XgGN/twpdNDjqS1TUM7YFNEtQYWk+dKAnH+T1gr6QgCoGMPl487xw/9hXooa2g==}
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
@@ -1086,6 +1092,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.26.0
 
+  '@types/bootstrap@5.2.10':
+    dependencies:
+      '@popperjs/core': 2.11.8
+
   '@types/estree@1.0.6': {}
 
   babel-plugin-jsx-dom-expressions@0.39.3(@babel/core@7.26.0):
@@ -1316,7 +1326,7 @@ snapshots:
 
   validate-html-nesting@1.2.2: {}
 
-  vite-plugin-solid@2.11.0(solid-js@1.9.3)(vite@6.0.0):
+  vite-plugin-solid@2.11.0(solid-js@1.9.3)(vite@6.0.0(sass@1.81.0)):
     dependencies:
       '@babel/core': 7.26.0
       '@types/babel__core': 7.20.5
@@ -1325,7 +1335,7 @@ snapshots:
       solid-js: 1.9.3
       solid-refresh: 0.6.3(solid-js@1.9.3)
       vite: 6.0.0(sass@1.81.0)
-      vitefu: 1.0.4(vite@6.0.0)
+      vitefu: 1.0.4(vite@6.0.0(sass@1.81.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -1334,12 +1344,12 @@ snapshots:
       esbuild: 0.24.0
       postcss: 8.4.49
       rollup: 4.27.4
-      sass: 1.81.0
     optionalDependencies:
       fsevents: 2.3.3
+      sass: 1.81.0
 
-  vitefu@1.0.4(vite@6.0.0):
-    dependencies:
+  vitefu@1.0.4(vite@6.0.0(sass@1.81.0)):
+    optionalDependencies:
       vite: 6.0.0(sass@1.81.0)
 
   yallist@3.1.1: {}

--- a/ts-bootstrap/src/App.tsx
+++ b/ts-bootstrap/src/App.tsx
@@ -1,5 +1,5 @@
 import { onCleanup, onMount } from 'solid-js';
-import type { Component } from 'solid-js';
+import { type Component } from 'solid-js';
 import * as bootstrap from 'bootstrap';
 
 const App: Component = () => {
@@ -19,7 +19,7 @@ const App: Component = () => {
     // @ts-ignore
     let parent = link.parentNode.parentNode.previousElementSibling;
 
-    link.classList.add('active');
+    link?.classList.add('active');
 
     if (parent.classList.contains('collapsed')) {
       parent.click();

--- a/ts-bootstrap/tsconfig.json
+++ b/ts-bootstrap/tsconfig.json
@@ -1,14 +1,31 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
+    "target": "es2020",
+    "lib": ["es2020", "dom", "dom.iterable"],
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
-    "types": ["vite/client"],
+    "useDefineForClassFields": true,
+
+    /* Modules */
+    "module": "preserve",
+    "moduleDetection": "force",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "esModuleInterop": true,
     "noEmit": true,
-    "isolatedModules": true
-  }
+
+    /* Type Checking & Safety */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "allowJs": true,
+    "skipLibCheck": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
 }

--- a/ts-jest/tsconfig.json
+++ b/ts-jest/tsconfig.json
@@ -1,16 +1,31 @@
 {
-  "types": ["jest", "@testing-library/jest-dom"],
   "compilerOptions": {
-    "strict": true,
-    "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
+    "target": "es2020",
+    "lib": ["es2020", "dom", "dom.iterable"],
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
-    "types": ["vite/client"],
+    "useDefineForClassFields": true,
+
+    /* Modules */
+    "module": "preserve",
+    "moduleDetection": "force",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "esModuleInterop": true,
     "noEmit": true,
-    "isolatedModules": true
-  }
+
+    /* Type Checking & Safety */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "allowJs": true,
+    "skipLibCheck": true,
+    "types": ["vite/client", "jest", "@testing-library/jest-dom"]
+  },
+  "include": ["src"]
 }

--- a/ts-minimal/src/App.tsx
+++ b/ts-minimal/src/App.tsx
@@ -1,4 +1,4 @@
-import type { Component } from 'solid-js';
+import { type Component } from 'solid-js';
 import Comp from './Comp';
 
 const App: Component = () => {

--- a/ts-minimal/tsconfig.json
+++ b/ts-minimal/tsconfig.json
@@ -1,14 +1,31 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
+    "target": "es2020",
+    "lib": ["es2020", "dom", "dom.iterable"],
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
-    "types": ["vite/client"],
+    "useDefineForClassFields": true,
+
+    /* Modules */
+    "module": "preserve",
+    "moduleDetection": "force",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "esModuleInterop": true,
     "noEmit": true,
-    "isolatedModules": true
-  }
+
+    /* Type Checking & Safety */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "allowJs": true,
+    "skipLibCheck": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
 }

--- a/ts-router/package.json
+++ b/ts-router/package.json
@@ -11,6 +11,7 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "typescript": "^5.7.2",
     "autoprefixer": "^10.4.20",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.15",

--- a/ts-router/pnpm-lock.yaml
+++ b/ts-router/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       tailwindcss:
         specifier: ^3.4.15
         version: 3.4.15
+      typescript:
+        specifier: ^5.7.2
+        version: 5.7.2
       vite:
         specifier: ^6.0.0
         version: 6.0.0(jiti@1.21.6)(yaml@2.6.1)
@@ -979,6 +982,11 @@ packages:
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  typescript@5.7.2:
+    resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   update-browserslist-db@1.0.13:
     resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
@@ -1957,6 +1965,8 @@ snapshots:
       is-number: 7.0.0
 
   ts-interface-checker@0.1.13: {}
+
+  typescript@5.7.2: {}
 
   update-browserslist-db@1.0.13(browserslist@4.22.2):
     dependencies:

--- a/ts-router/src/app.tsx
+++ b/ts-router/src/app.tsx
@@ -1,7 +1,7 @@
-import { Suspense, type Component } from 'solid-js';
+import { Suspense, type ParentComponent } from 'solid-js';
 import { A, useLocation } from '@solidjs/router';
 
-const App: Component = (props: { children: Element }) => {
+const App: ParentComponent = (props) => {
   const location = useLocation();
 
   return (

--- a/ts-router/src/index.tsx
+++ b/ts-router/src/index.tsx
@@ -1,7 +1,7 @@
 /* @refresh reload */
 import './index.css';
 
-import { render, Suspense } from 'solid-js/web';
+import { render } from 'solid-js/web';
 
 import App from './app';
 import { Router } from '@solidjs/router';
@@ -17,5 +17,5 @@ if (import.meta.env.DEV && !(root instanceof HTMLElement)) {
 
 render(
   () => <Router root={(props) => <App>{props.children}</App>}>{routes}</Router>,
-  root,
+  root!,
 );

--- a/ts-router/src/routes.ts
+++ b/ts-router/src/routes.ts
@@ -1,5 +1,5 @@
 import { lazy } from 'solid-js';
-import type { RouteDefinition } from '@solidjs/router';
+import { type RouteDefinition } from '@solidjs/router';
 
 import Home from './pages/home';
 import AboutData from './pages/about.data';
@@ -12,7 +12,7 @@ export const routes: RouteDefinition[] = [
   {
     path: '/about',
     component: lazy(() => import('./pages/about')),
-    data: AboutData,
+    preload: AboutData,
   },
   {
     path: '**',

--- a/ts-router/tailwind.config.ts
+++ b/ts-router/tailwind.config.ts
@@ -1,4 +1,4 @@
-import type { Config } from 'tailwindcss';
+import { type Config } from 'tailwindcss';
 
 const config: Config = {
   content: ['./src/**/*.{js,jsx,ts,tsx}'],

--- a/ts-router/tsconfig.json
+++ b/ts-router/tsconfig.json
@@ -1,14 +1,31 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
+    "target": "es2020",
+    "lib": ["es2020", "dom", "dom.iterable"],
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
-    "types": ["vite/client"],
+    "useDefineForClassFields": true,
+
+    /* Modules */
+    "module": "preserve",
+    "moduleDetection": "force",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "esModuleInterop": true,
     "noEmit": true,
-    "isolatedModules": true
-  }
+
+    /* Type Checking & Safety */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "allowJs": true,
+    "skipLibCheck": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
 }

--- a/ts-sass/src/App.tsx
+++ b/ts-sass/src/App.tsx
@@ -1,6 +1,6 @@
 import './App.scss';
 
-import { Component, createSignal } from 'solid-js';
+import { type Component, createSignal } from 'solid-js';
 import Counter from './Counter';
 
 const App: Component = () => {

--- a/ts-sass/tsconfig.json
+++ b/ts-sass/tsconfig.json
@@ -1,14 +1,31 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
+    "target": "es2020",
+    "lib": ["es2020", "dom", "dom.iterable"],
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
-    "types": ["vite/client"],
+    "useDefineForClassFields": true,
+
+    /* Modules */
+    "module": "preserve",
+    "moduleDetection": "force",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "esModuleInterop": true,
     "noEmit": true,
-    "isolatedModules": true
-  }
+
+    /* Type Checking & Safety */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "allowJs": true,
+    "skipLibCheck": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
 }

--- a/ts-tailwindcss/src/App.tsx
+++ b/ts-tailwindcss/src/App.tsx
@@ -1,4 +1,4 @@
-import type { Component } from 'solid-js';
+import { type Component } from 'solid-js';
 
 const App: Component = () => {
   return (

--- a/ts-tailwindcss/tailwind.config.ts
+++ b/ts-tailwindcss/tailwind.config.ts
@@ -1,4 +1,4 @@
-import type { Config } from 'tailwindcss';
+import { type Config } from 'tailwindcss';
 
 const config: Config = {
   content: [

--- a/ts-tailwindcss/tsconfig.json
+++ b/ts-tailwindcss/tsconfig.json
@@ -1,14 +1,31 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
+    "target": "es2020",
+    "lib": ["es2020", "dom", "dom.iterable"],
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
-    "types": ["vite/client"],
+    "useDefineForClassFields": true,
+
+    /* Modules */
+    "module": "preserve",
+    "moduleDetection": "force",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "esModuleInterop": true,
     "noEmit": true,
-    "isolatedModules": true
-  }
+
+    /* Type Checking & Safety */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "allowJs": true,
+    "skipLibCheck": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
 }

--- a/ts-unocss/src/App.tsx
+++ b/ts-unocss/src/App.tsx
@@ -1,4 +1,4 @@
-import type { Component } from 'solid-js';
+import { type Component } from 'solid-js';
 
 const App: Component = () => {
   return (

--- a/ts-unocss/tsconfig.json
+++ b/ts-unocss/tsconfig.json
@@ -1,14 +1,31 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
+    "target": "es2020",
+    "lib": ["es2020", "dom", "dom.iterable"],
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
-    "types": ["vite/client"],
+    "useDefineForClassFields": true,
+
+    /* Modules */
+    "module": "preserve",
+    "moduleDetection": "force",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "esModuleInterop": true,
     "noEmit": true,
-    "isolatedModules": true
-  }
+
+    /* Type Checking & Safety */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "allowJs": true,
+    "skipLibCheck": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
 }

--- a/ts-uvu/.gitignore
+++ b/ts-uvu/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/ts-uvu/tsconfig.json
+++ b/ts-uvu/tsconfig.json
@@ -1,13 +1,31 @@
 {
   "compilerOptions": {
-    "strict": true,
-    "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
+    "target": "es2020",
+    "lib": ["es2020", "dom", "dom.iterable"],
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
+    "useDefineForClassFields": true,
+
+    /* Modules */
+    "module": "preserve",
+    "moduleDetection": "force",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+
+    /* Type Checking & Safety */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "allowJs": true,
+    "skipLibCheck": true,
     "types": ["vite/client"]
-  }
+  },
+  "include": ["src"]
 }

--- a/ts-vitest/.gitignore
+++ b/ts-vitest/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/ts-vitest/pnpm-lock.yaml
+++ b/ts-vitest/pnpm-lock.yaml
@@ -21,9 +21,6 @@ importers:
       jsdom:
         specifier: ^25.0.1
         version: 25.0.1
-      solid-devtools:
-        specifier: ^0.30.1
-        version: 0.30.1(solid-js@1.9.3)(vite@6.0.0)
       typescript:
         specifier: ^5.7.2
         version: 5.7.2
@@ -107,12 +104,6 @@ packages:
 
   '@babel/plugin-syntax-jsx@7.25.9':
     resolution: {integrity: sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-typescript@7.25.9':
-    resolution: {integrity: sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -295,9 +286,6 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
-  '@nothing-but/utils@0.12.1':
-    resolution: {integrity: sha512-1qZU1Q5El0IjE7JT/ucvJNzdr2hL3W8Rm27xNf1p6gb3Nw8pGnZmxp6/GEW9h+I1k1cICxXNq25hBwknTQ7yhg==}
-
   '@rollup/rollup-android-arm-eabi@4.27.4':
     resolution: {integrity: sha512-2Y3JT6f5MrQkICUyRVCw4oa0sutfAsgaSsb0Lmmy1Wi2y7X5vT9Euqw4gOsCyy0YfKURBg35nhUKZS4mDcfULw==}
     cpu: [arm]
@@ -387,91 +375,6 @@ packages:
     resolution: {integrity: sha512-3j4jx1TppORdTAoBJRd+/wJRGCPC0ETWkXOecJ6PPZLj6SptXkrXcNqdj0oclbKML6FkQltdz7bBA3rUSirZug==}
     cpu: [x64]
     os: [win32]
-
-  '@solid-devtools/debugger@0.23.4':
-    resolution: {integrity: sha512-EfTB1Eo313wztQYGJ4Ec/wE70Ay2d603VCXfT3RlyqO5QfLrQGRHX5NXC07hJpQTJJJ3tbNgzO7+ZKo76MM5uA==}
-    peerDependencies:
-      solid-js: ^1.8.0
-
-  '@solid-devtools/shared@0.13.2':
-    resolution: {integrity: sha512-Y4uaC4EfTVwBR537MZwfaY/eiWAh+hW4mbtnwNuUw/LFmitHSkQhNQTUlLQv/S0chtwrYWQBxvXos1dC7e8R9g==}
-    peerDependencies:
-      solid-js: ^1.8.0
-
-  '@solid-primitives/bounds@0.0.118':
-    resolution: {integrity: sha512-Qj42w8LlnhJ3r/t+t0c0vrdwIvvQMPgjEFGmLiwREaA85ojLbgL9lSBq2tKvljeLCvRVkgj10KEUf+vc99VCIg==}
-    peerDependencies:
-      solid-js: ^1.6.12
-
-  '@solid-primitives/cursor@0.0.112':
-    resolution: {integrity: sha512-TAtU7qD7ipSLSXHnq8FhhosAPVX+dnOCb/ITcGcLlj8e/C9YKcxDhgBHJ3R/d1xDRb5/vO/szJtEz6fnQD311Q==}
-    peerDependencies:
-      solid-js: ^1.6.12
-
-  '@solid-primitives/event-bus@1.0.11':
-    resolution: {integrity: sha512-bSwVA4aI2aNHomSbEroUnisMSyDDXJbrw4U8kFEvrcYdlLrJX5i6QeCFx+vj/zdQQw62KAllrEIyWP8KMpPVnQ==}
-    peerDependencies:
-      solid-js: ^1.6.12
-
-  '@solid-primitives/event-listener@2.3.3':
-    resolution: {integrity: sha512-DAJbl+F0wrFW2xmcV8dKMBhk9QLVLuBSW+TR4JmIfTaObxd13PuL7nqaXnaYKDWOYa6otB00qcCUIGbuIhSUgQ==}
-    peerDependencies:
-      solid-js: ^1.6.12
-
-  '@solid-primitives/keyboard@1.2.8':
-    resolution: {integrity: sha512-pJtcbkjozS6L1xvTht9rPpyPpX55nAkfBzbFWdf3y0Suwh6qClTibvvObzKOf7uzQ+8aZRDH4LsoGmbTKXtJjQ==}
-    peerDependencies:
-      solid-js: ^1.6.12
-
-  '@solid-primitives/media@2.2.9':
-    resolution: {integrity: sha512-QUmU62D4/d9YWx/4Dvr/UZasIkIpqNXz7wosA5GLmesRW9XlPa3G5M6uOmTw73SByHNTCw0D6x8bSdtvvLgzvQ==}
-    peerDependencies:
-      solid-js: ^1.6.12
-
-  '@solid-primitives/platform@0.1.2':
-    resolution: {integrity: sha512-sSxcZfuUrtxcwV0vdjmGnZQcflACzMfLriVeIIWXKp8hzaS3Or3tO6EFQkTd3L8T5dTq+kTtLvPscXIpL0Wzdg==}
-    peerDependencies:
-      solid-js: ^1.6.12
-
-  '@solid-primitives/refs@1.0.8':
-    resolution: {integrity: sha512-+jIsWG8/nYvhaCoG2Vg6CJOLgTmPKFbaCrNQKWfChalgUf9WrVxWw0CdJb3yX15n5lUcQ0jBo6qYtuVVmBLpBw==}
-    peerDependencies:
-      solid-js: ^1.6.12
-
-  '@solid-primitives/resize-observer@2.0.26':
-    resolution: {integrity: sha512-KbPhwal6ML9OHeUTZszBbt6PYSMj89d4wVCLxlvDYL4U0+p+xlCEaqz6v9dkCwm/0Lb+Wed7W5T1dQZCP3JUUw==}
-    peerDependencies:
-      solid-js: ^1.6.12
-
-  '@solid-primitives/rootless@1.4.5':
-    resolution: {integrity: sha512-GFJE9GC3ojx0aUKqAUZmQPyU8fOVMtnVNrkdk2yS4kd17WqVSpXpoTmo9CnOwA+PG7FTzdIkogvfLQSLs4lrww==}
-    peerDependencies:
-      solid-js: ^1.6.12
-
-  '@solid-primitives/scheduled@1.4.4':
-    resolution: {integrity: sha512-BTGdFP7t+s7RSak+s1u0eTix4lHP23MrbGkgQTFlt1E+4fmnD/bEx3ZfNW7Grylz3GXgKyXrgDKA7jQ/wuWKgA==}
-    peerDependencies:
-      solid-js: ^1.6.12
-
-  '@solid-primitives/static-store@0.0.5':
-    resolution: {integrity: sha512-ssQ+s/wrlFAEE4Zw8GV499yBfvWx7SMm+ZVc11wvao4T5xg9VfXCL9Oa+x4h+vPMvSV/Knv5LrsLiUa+wlJUXQ==}
-    peerDependencies:
-      solid-js: ^1.6.12
-
-  '@solid-primitives/static-store@0.0.8':
-    resolution: {integrity: sha512-ZecE4BqY0oBk0YG00nzaAWO5Mjcny8Fc06CdbXadH9T9lzq/9GefqcSe/5AtdXqjvY/DtJ5C6CkcjPZO0o/eqg==}
-    peerDependencies:
-      solid-js: ^1.6.12
-
-  '@solid-primitives/styles@0.0.111':
-    resolution: {integrity: sha512-1mBxOGAPXmfD5oYCvqjKBDN7SuNjz2qz7RdH7KtsuNLQh6lpuSKadtHnLvru0Y8Vz1InqTJisBIy/6P5kyDmPw==}
-    peerDependencies:
-      solid-js: ^1.6.12
-
-  '@solid-primitives/utils@6.2.3':
-    resolution: {integrity: sha512-CqAwKb2T5Vi72+rhebSsqNZ9o67buYRdEJrIFzRXz3U59QqezuuxPsyzTSVCacwS5Pf109VRsgCJQoxKRoECZQ==}
-    peerDependencies:
-      solid-js: ^1.6.12
 
   '@solidjs/testing-library@0.8.10':
     resolution: {integrity: sha512-qdeuIerwyq7oQTIrrKvV0aL9aFeuwTd86VYD3afdq5HYEwoox1OBTJy4y8A3TFZr8oAR0nujYgCzY/8wgHGfeQ==}
@@ -876,18 +779,6 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
-  solid-devtools@0.30.1:
-    resolution: {integrity: sha512-axpXL4JV1dnGhuei+nSGS8ewGeNkmIgFDsAlO90YyYY5t8wU1R0aYAQtL+I+5KICLKPBvfkzdcFa2br7AV4lAw==}
-    peerDependencies:
-      solid-js: ^1.8.0
-      solid-start: ^0.3.0
-      vite: ^2.2.3 || ^3.0.0 || ^4.0.0 || ^5.0.0
-    peerDependenciesMeta:
-      solid-start:
-        optional: true
-      vite:
-        optional: true
-
   solid-js@1.9.3:
     resolution: {integrity: sha512-5ba3taPoZGt9GY3YlsCB24kCg0Lv/rie/HTD4kG6h4daZZz7+yK02xn8Vx8dLYBc9i6Ps5JwAbEiqjmKaLB3Ag==}
 
@@ -1194,11 +1085,6 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-typescript@7.25.9(@babel/core@7.26.0)':
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-
   '@babel/runtime@7.26.0':
     dependencies:
       regenerator-runtime: 0.14.1
@@ -1315,8 +1201,6 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@nothing-but/utils@0.12.1': {}
-
   '@rollup/rollup-android-arm-eabi@4.27.4':
     optional: true
 
@@ -1370,119 +1254,6 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.27.4':
     optional: true
-
-  '@solid-devtools/debugger@0.23.4(solid-js@1.9.3)':
-    dependencies:
-      '@nothing-but/utils': 0.12.1
-      '@solid-devtools/shared': 0.13.2(solid-js@1.9.3)
-      '@solid-primitives/bounds': 0.0.118(solid-js@1.9.3)
-      '@solid-primitives/cursor': 0.0.112(solid-js@1.9.3)
-      '@solid-primitives/event-bus': 1.0.11(solid-js@1.9.3)
-      '@solid-primitives/event-listener': 2.3.3(solid-js@1.9.3)
-      '@solid-primitives/keyboard': 1.2.8(solid-js@1.9.3)
-      '@solid-primitives/platform': 0.1.2(solid-js@1.9.3)
-      '@solid-primitives/rootless': 1.4.5(solid-js@1.9.3)
-      '@solid-primitives/scheduled': 1.4.4(solid-js@1.9.3)
-      '@solid-primitives/static-store': 0.0.5(solid-js@1.9.3)
-      '@solid-primitives/utils': 6.2.3(solid-js@1.9.3)
-      solid-js: 1.9.3
-
-  '@solid-devtools/shared@0.13.2(solid-js@1.9.3)':
-    dependencies:
-      '@solid-primitives/event-bus': 1.0.11(solid-js@1.9.3)
-      '@solid-primitives/event-listener': 2.3.3(solid-js@1.9.3)
-      '@solid-primitives/media': 2.2.9(solid-js@1.9.3)
-      '@solid-primitives/refs': 1.0.8(solid-js@1.9.3)
-      '@solid-primitives/rootless': 1.4.5(solid-js@1.9.3)
-      '@solid-primitives/scheduled': 1.4.4(solid-js@1.9.3)
-      '@solid-primitives/static-store': 0.0.5(solid-js@1.9.3)
-      '@solid-primitives/styles': 0.0.111(solid-js@1.9.3)
-      '@solid-primitives/utils': 6.2.3(solid-js@1.9.3)
-      solid-js: 1.9.3
-
-  '@solid-primitives/bounds@0.0.118(solid-js@1.9.3)':
-    dependencies:
-      '@solid-primitives/event-listener': 2.3.3(solid-js@1.9.3)
-      '@solid-primitives/resize-observer': 2.0.26(solid-js@1.9.3)
-      '@solid-primitives/static-store': 0.0.5(solid-js@1.9.3)
-      '@solid-primitives/utils': 6.2.3(solid-js@1.9.3)
-      solid-js: 1.9.3
-
-  '@solid-primitives/cursor@0.0.112(solid-js@1.9.3)':
-    dependencies:
-      '@solid-primitives/utils': 6.2.3(solid-js@1.9.3)
-      solid-js: 1.9.3
-
-  '@solid-primitives/event-bus@1.0.11(solid-js@1.9.3)':
-    dependencies:
-      '@solid-primitives/utils': 6.2.3(solid-js@1.9.3)
-      solid-js: 1.9.3
-
-  '@solid-primitives/event-listener@2.3.3(solid-js@1.9.3)':
-    dependencies:
-      '@solid-primitives/utils': 6.2.3(solid-js@1.9.3)
-      solid-js: 1.9.3
-
-  '@solid-primitives/keyboard@1.2.8(solid-js@1.9.3)':
-    dependencies:
-      '@solid-primitives/event-listener': 2.3.3(solid-js@1.9.3)
-      '@solid-primitives/rootless': 1.4.5(solid-js@1.9.3)
-      '@solid-primitives/utils': 6.2.3(solid-js@1.9.3)
-      solid-js: 1.9.3
-
-  '@solid-primitives/media@2.2.9(solid-js@1.9.3)':
-    dependencies:
-      '@solid-primitives/event-listener': 2.3.3(solid-js@1.9.3)
-      '@solid-primitives/rootless': 1.4.5(solid-js@1.9.3)
-      '@solid-primitives/static-store': 0.0.8(solid-js@1.9.3)
-      '@solid-primitives/utils': 6.2.3(solid-js@1.9.3)
-      solid-js: 1.9.3
-
-  '@solid-primitives/platform@0.1.2(solid-js@1.9.3)':
-    dependencies:
-      solid-js: 1.9.3
-
-  '@solid-primitives/refs@1.0.8(solid-js@1.9.3)':
-    dependencies:
-      '@solid-primitives/utils': 6.2.3(solid-js@1.9.3)
-      solid-js: 1.9.3
-
-  '@solid-primitives/resize-observer@2.0.26(solid-js@1.9.3)':
-    dependencies:
-      '@solid-primitives/event-listener': 2.3.3(solid-js@1.9.3)
-      '@solid-primitives/rootless': 1.4.5(solid-js@1.9.3)
-      '@solid-primitives/static-store': 0.0.8(solid-js@1.9.3)
-      '@solid-primitives/utils': 6.2.3(solid-js@1.9.3)
-      solid-js: 1.9.3
-
-  '@solid-primitives/rootless@1.4.5(solid-js@1.9.3)':
-    dependencies:
-      '@solid-primitives/utils': 6.2.3(solid-js@1.9.3)
-      solid-js: 1.9.3
-
-  '@solid-primitives/scheduled@1.4.4(solid-js@1.9.3)':
-    dependencies:
-      solid-js: 1.9.3
-
-  '@solid-primitives/static-store@0.0.5(solid-js@1.9.3)':
-    dependencies:
-      '@solid-primitives/utils': 6.2.3(solid-js@1.9.3)
-      solid-js: 1.9.3
-
-  '@solid-primitives/static-store@0.0.8(solid-js@1.9.3)':
-    dependencies:
-      '@solid-primitives/utils': 6.2.3(solid-js@1.9.3)
-      solid-js: 1.9.3
-
-  '@solid-primitives/styles@0.0.111(solid-js@1.9.3)':
-    dependencies:
-      '@solid-primitives/rootless': 1.4.5(solid-js@1.9.3)
-      '@solid-primitives/utils': 6.2.3(solid-js@1.9.3)
-      solid-js: 1.9.3
-
-  '@solid-primitives/utils@6.2.3(solid-js@1.9.3)':
-    dependencies:
-      solid-js: 1.9.3
 
   '@solidjs/testing-library@0.8.10(solid-js@1.9.3)':
     dependencies:
@@ -1914,19 +1685,6 @@ snapshots:
   seroval@1.1.1: {}
 
   siginfo@2.0.0: {}
-
-  solid-devtools@0.30.1(solid-js@1.9.3)(vite@6.0.0):
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.26.0)
-      '@babel/types': 7.26.0
-      '@solid-devtools/debugger': 0.23.4(solid-js@1.9.3)
-      '@solid-devtools/shared': 0.13.2(solid-js@1.9.3)
-      solid-js: 1.9.3
-    optionalDependencies:
-      vite: 6.0.0
-    transitivePeerDependencies:
-      - supports-color
 
   solid-js@1.9.3:
     dependencies:

--- a/ts-vitest/src/todo-list.test.tsx
+++ b/ts-vitest/src/todo-list.test.tsx
@@ -1,4 +1,5 @@
 import { render, fireEvent } from '@solidjs/testing-library';
+import { describe, test, expect } from 'vitest';
 
 import { TodoList } from './todo-list';
 

--- a/ts-vitest/tsconfig.json
+++ b/ts-vitest/tsconfig.json
@@ -1,13 +1,31 @@
 {
   "compilerOptions": {
-    "strict": true,
-    "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
+    "target": "es2020",
+    "lib": ["es2020", "dom", "dom.iterable"],
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
+    "useDefineForClassFields": true,
+
+    /* Modules */
+    "module": "preserve",
+    "moduleDetection": "force",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+
+    /* Type Checking & Safety */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "allowJs": true,
+    "skipLibCheck": true,
     "types": ["vite/client", "@testing-library/jest-dom"]
-  }
+  },
+  "include": ["src"]
 }

--- a/ts/src/App.tsx
+++ b/ts/src/App.tsx
@@ -1,4 +1,4 @@
-import type { Component } from 'solid-js';
+import { type Component } from 'solid-js';
 
 import logo from './logo.svg';
 import styles from './App.module.css';

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -1,15 +1,31 @@
 {
   "compilerOptions": {
-    "strict": true,
-    "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
+    "target": "es2020",
+    "lib": ["es2020", "dom", "dom.iterable"],
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
-    "types": ["vite/client"],
+    "useDefineForClassFields": true,
+
+    /* Modules */
+    "module": "preserve",
+    "moduleDetection": "force",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "esModuleInterop": true,
     "noEmit": true,
-    "isolatedModules": true
-  }
+
+    /* Type Checking & Safety */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "allowJs": true,
+    "skipLibCheck": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
 }


### PR DESCRIPTION
Your TSConfig hasn't been updated for over 2 years. I didn't have any particular issue with it, but I think it benefits from an update.

The TSConfig I used is based on [this guide](https://www.totaltypescript.com/tsconfig-cheat-sheet) and Vite's default TSConfig for React.

I ran `pnpm build` and `pnpm tsc --noEmit` to ensure all templates build  correctly and found (and fixed) all sorts of wired bugs and inconsistencies. For example, missing packages, missing `.gitignore` file or TypeScript errors. I didn't feel like creating a separate PR for it, but if you are strict with this sort of stuff I can divide it into two PRs. 