### PR TITLE
use devtools in router examples

### DIFF
--- a/tanstack-router-config-based/package.json
+++ b/tanstack-router-config-based/package.json
@@ -9,7 +9,8 @@
     "start": "vite"
   },
   "dependencies": {
-    "@tanstack/solid-router": "^1.108.0",
+    "@tanstack/solid-router": "^1.112.18",
+    "@tanstack/solid-router-devtools": "^1.114.0",
     "solid-js": "^1.9.5",
     "redaxios": "^0.5.1",
     "postcss": "^8.5.1",

--- a/tanstack-router-config-based/pnpm-lock.yaml
+++ b/tanstack-router-config-based/pnpm-lock.yaml
@@ -9,8 +9,11 @@ importers:
   .:
     dependencies:
       '@tanstack/solid-router':
-        specifier: ^1.108.0
-        version: 1.108.0(solid-js@1.9.5)
+        specifier: ^1.112.18
+        version: 1.112.18(solid-js@1.9.5)
+      '@tanstack/solid-router-devtools':
+        specifier: ^1.114.0
+        version: 1.114.0(@tanstack/router-devtools-core@1.114.0(@tanstack/router-core@1.112.18)(csstype@3.1.3)(solid-js@1.9.5)(tiny-invariant@1.3.3))(@tanstack/solid-router@1.112.18(solid-js@1.9.5))(solid-js@1.9.5)
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.5.3)
@@ -495,19 +498,44 @@ packages:
     peerDependencies:
       solid-js: ^1.6.12
 
-  '@tanstack/history@1.99.13':
-    resolution: {integrity: sha512-JMd7USmnp8zV8BRGIjALqzPxazvKtQ7PGXQC7n39HpbqdsmfV2ePCzieO84IvN+mwsTrXErpbjI4BfKCa+ZNCg==}
+  '@solidjs/meta@0.29.4':
+    resolution: {integrity: sha512-zdIWBGpR9zGx1p1bzIPqF5Gs+Ks/BH8R6fWhmUa/dcK1L2rUC8BAcZJzNRYBQv74kScf1TSOs0EY//Vd/I0V8g==}
+    peerDependencies:
+      solid-js: '>=1.8.4'
+
+  '@tanstack/history@1.112.18':
+    resolution: {integrity: sha512-57QWQ0DWkhJGwUxFqzHD51tfCZmU5Bnl7KY7x3yaKvk/+uU7i0Pz7d4HFTFMl+pxq/Q/zmV8TyQSctM5MIZWvw==}
     engines: {node: '>=12'}
 
-  '@tanstack/router-core@1.108.0':
-    resolution: {integrity: sha512-lo6Nqdp8gxWNZ8YZ6UhiQgR0CgcAiMaw1cxgKK7M4u3nFFwqW7Hzycl5ik1l3NRh5/pQVK+OVzlKok5rrrHxSg==}
+  '@tanstack/router-core@1.112.18':
+    resolution: {integrity: sha512-OQ7qxpK6l0727LUzaDBNj6Wg4yBtYyIgTqThMFN2a5Tl7nNAFfjh4xfSljmXEMRmrcZTprdDpbD8NHq1wgLVvA==}
     engines: {node: '>=12'}
 
-  '@tanstack/solid-router@1.108.0':
-    resolution: {integrity: sha512-DKtrdy/BHCGvc8wP8xW0tuc8bgA6lPGynbT50Zq8PgYD0ObIUWVHO4kKBwAPBRJQwsesDGdInir1nRMa+8c6iw==}
+  '@tanstack/router-devtools-core@1.114.0':
+    resolution: {integrity: sha512-r+fmLwnUt99WRzSlmeD8gke7rbWyGH7H7HWAvsPuWFJWMxQ2CaKEBQe+kOSXpyV/WDrQwyNO8x7Vq6RF4iGahg==}
     engines: {node: '>=12'}
     peerDependencies:
-      solid-js: ^1
+      '@tanstack/router-core': ^1.112.18
+      csstype: ^3.0.10
+      solid-js: '>=1.9.5'
+      tiny-invariant: ^1.3.3
+    peerDependenciesMeta:
+      csstype:
+        optional: true
+
+  '@tanstack/solid-router-devtools@1.114.0':
+    resolution: {integrity: sha512-pEUY6OE+/Bt0p6vwsmsEOqfUA3RYE6Z+8A4voiDAHibwOypamaGfc8XyO7jS72X6F/i11FkLhkLwSObE/Z+yuQ==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      '@tanstack/router-devtools-core': ^1.114.0
+      '@tanstack/solid-router': ^1.112.18
+      solid-js: ^1.9.5
+
+  '@tanstack/solid-router@1.112.18':
+    resolution: {integrity: sha512-VtVkyDrYEaoAQJLZ4oUofLhJeUy+Om+/iKKALxrfSOOfWUZsXV4xO72E+yxiMiTPpfXqrBdKOKbTXzLY7lizBA==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      solid-js: ^1.9.5
 
   '@tanstack/solid-store@0.7.0':
     resolution: {integrity: sha512-uDQYkUuH3MppitiduZLTEcItkTr8vEJ33jzp2rH2VvlNRMGbuU54GQcqf3dLIlTbZ1/Z2TtIBtBjjl+N/OhwRg==}
@@ -604,6 +632,10 @@ packages:
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -716,6 +748,11 @@ packages:
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
+
+  goober@2.1.16:
+    resolution: {integrity: sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==}
+    peerDependencies:
+      csstype: ^3.0.10
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
@@ -1533,19 +1570,40 @@ snapshots:
     dependencies:
       solid-js: 1.9.5
 
-  '@tanstack/history@1.99.13': {}
-
-  '@tanstack/router-core@1.108.0':
+  '@solidjs/meta@0.29.4(solid-js@1.9.5)':
     dependencies:
-      '@tanstack/history': 1.99.13
+      solid-js: 1.9.5
+
+  '@tanstack/history@1.112.18': {}
+
+  '@tanstack/router-core@1.112.18':
+    dependencies:
+      '@tanstack/history': 1.112.18
       '@tanstack/store': 0.7.0
 
-  '@tanstack/solid-router@1.108.0(solid-js@1.9.5)':
+  '@tanstack/router-devtools-core@1.114.0(@tanstack/router-core@1.112.18)(csstype@3.1.3)(solid-js@1.9.5)(tiny-invariant@1.3.3)':
+    dependencies:
+      '@tanstack/router-core': 1.112.18
+      clsx: 2.1.1
+      goober: 2.1.16(csstype@3.1.3)
+      solid-js: 1.9.5
+      tiny-invariant: 1.3.3
+    optionalDependencies:
+      csstype: 3.1.3
+
+  '@tanstack/solid-router-devtools@1.114.0(@tanstack/router-devtools-core@1.114.0(@tanstack/router-core@1.112.18)(csstype@3.1.3)(solid-js@1.9.5)(tiny-invariant@1.3.3))(@tanstack/solid-router@1.112.18(solid-js@1.9.5))(solid-js@1.9.5)':
+    dependencies:
+      '@tanstack/router-devtools-core': 1.114.0(@tanstack/router-core@1.112.18)(csstype@3.1.3)(solid-js@1.9.5)(tiny-invariant@1.3.3)
+      '@tanstack/solid-router': 1.112.18(solid-js@1.9.5)
+      solid-js: 1.9.5
+
+  '@tanstack/solid-router@1.112.18(solid-js@1.9.5)':
     dependencies:
       '@solid-devtools/logger': 0.9.7(solid-js@1.9.5)
       '@solid-primitives/refs': 1.1.0(solid-js@1.9.5)
-      '@tanstack/history': 1.99.13
-      '@tanstack/router-core': 1.108.0
+      '@solidjs/meta': 0.29.4(solid-js@1.9.5)
+      '@tanstack/history': 1.112.18
+      '@tanstack/router-core': 1.112.18
       '@tanstack/solid-store': 0.7.0(solid-js@1.9.5)
       jsesc: 3.1.0
       solid-js: 1.9.5
@@ -1660,6 +1718,8 @@ snapshots:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  clsx@2.1.1: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -1777,6 +1837,10 @@ snapshots:
       path-scurry: 1.11.1
 
   globals@11.12.0: {}
+
+  goober@2.1.16(csstype@3.1.3):
+    dependencies:
+      csstype: 3.1.3
 
   hasown@2.0.2:
     dependencies:

--- a/tanstack-router-config-based/src/main.tsx
+++ b/tanstack-router-config-based/src/main.tsx
@@ -11,6 +11,7 @@ import {
 import { NotFoundError, fetchPost, fetchPosts } from './posts';
 import type { ErrorComponentProps } from '@tanstack/solid-router';
 import './styles.css';
+import { TanStackRouterDevtools } from '@tanstack/solid-router-devtools';
 
 const rootRoute = createRootRoute({
   component: RootComponent,
@@ -64,6 +65,7 @@ function RootComponent() {
         </Link>
       </div>
       <Outlet />
+      <TanStackRouterDevtools position="bottom-right" />
     </>
   );
 }

--- a/tanstack-router-file-based/package.json
+++ b/tanstack-router-file-based/package.json
@@ -9,8 +9,9 @@
     "start": "vite"
   },
   "dependencies": {
-    "@tanstack/solid-router": "^1.108.0",
-    "@tanstack/router-plugin": "^1.108.0",
+    "@tanstack/solid-router": "^1.112.18",
+    "@tanstack/solid-router-devtools": "^1.114.0",
+    "@tanstack/router-plugin": "^1.113.0",
     "solid-js": "^1.9.5",
     "redaxios": "^0.5.1",
     "postcss": "^8.5.1",

--- a/tanstack-router-file-based/pnpm-lock.yaml
+++ b/tanstack-router-file-based/pnpm-lock.yaml
@@ -9,11 +9,14 @@ importers:
   .:
     dependencies:
       '@tanstack/router-plugin':
-        specifier: ^1.108.0
-        version: 1.108.0(vite-plugin-solid@2.11.6(solid-js@1.9.5)(vite@6.1.1(jiti@1.21.7)(tsx@4.19.3)(yaml@2.7.0)))(vite@6.1.1(jiti@1.21.7)(tsx@4.19.3)(yaml@2.7.0))
+        specifier: ^1.113.0
+        version: 1.113.0(vite-plugin-solid@2.11.6(solid-js@1.9.5)(vite@6.1.1(jiti@1.21.7)(tsx@4.19.3)(yaml@2.7.0)))(vite@6.1.1(jiti@1.21.7)(tsx@4.19.3)(yaml@2.7.0))
       '@tanstack/solid-router':
-        specifier: ^1.108.0
-        version: 1.108.0(solid-js@1.9.5)
+        specifier: ^1.112.18
+        version: 1.112.18(solid-js@1.9.5)
+      '@tanstack/solid-router-devtools':
+        specifier: ^1.114.0
+        version: 1.114.0(@tanstack/router-devtools-core@1.114.0(@tanstack/router-core@1.112.18)(csstype@3.1.3)(solid-js@1.9.5)(tiny-invariant@1.3.3))(@tanstack/solid-router@1.112.18(solid-js@1.9.5))(solid-js@1.9.5)
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.5.3)
@@ -657,29 +660,46 @@ packages:
     peerDependencies:
       solid-js: ^1.6.12
 
-  '@tanstack/history@1.99.13':
-    resolution: {integrity: sha512-JMd7USmnp8zV8BRGIjALqzPxazvKtQ7PGXQC7n39HpbqdsmfV2ePCzieO84IvN+mwsTrXErpbjI4BfKCa+ZNCg==}
+  '@solidjs/meta@0.29.4':
+    resolution: {integrity: sha512-zdIWBGpR9zGx1p1bzIPqF5Gs+Ks/BH8R6fWhmUa/dcK1L2rUC8BAcZJzNRYBQv74kScf1TSOs0EY//Vd/I0V8g==}
+    peerDependencies:
+      solid-js: '>=1.8.4'
+
+  '@tanstack/history@1.112.18':
+    resolution: {integrity: sha512-57QWQ0DWkhJGwUxFqzHD51tfCZmU5Bnl7KY7x3yaKvk/+uU7i0Pz7d4HFTFMl+pxq/Q/zmV8TyQSctM5MIZWvw==}
     engines: {node: '>=12'}
 
-  '@tanstack/router-core@1.108.0':
-    resolution: {integrity: sha512-lo6Nqdp8gxWNZ8YZ6UhiQgR0CgcAiMaw1cxgKK7M4u3nFFwqW7Hzycl5ik1l3NRh5/pQVK+OVzlKok5rrrHxSg==}
+  '@tanstack/router-core@1.112.18':
+    resolution: {integrity: sha512-OQ7qxpK6l0727LUzaDBNj6Wg4yBtYyIgTqThMFN2a5Tl7nNAFfjh4xfSljmXEMRmrcZTprdDpbD8NHq1wgLVvA==}
     engines: {node: '>=12'}
 
-  '@tanstack/router-generator@1.108.0':
-    resolution: {integrity: sha512-Ciw2lwmRzGjhn8xq/MsihQydXuworvQoVf1JNKL5KShTiWLlzP0wVpqY2mLP6+LS9bQrPKs1hSM8m3XNRP3U0w==}
+  '@tanstack/router-devtools-core@1.114.0':
+    resolution: {integrity: sha512-r+fmLwnUt99WRzSlmeD8gke7rbWyGH7H7HWAvsPuWFJWMxQ2CaKEBQe+kOSXpyV/WDrQwyNO8x7Vq6RF4iGahg==}
     engines: {node: '>=12'}
     peerDependencies:
-      '@tanstack/react-router': ^1.108.0
+      '@tanstack/router-core': ^1.112.18
+      csstype: ^3.0.10
+      solid-js: '>=1.9.5'
+      tiny-invariant: ^1.3.3
+    peerDependenciesMeta:
+      csstype:
+        optional: true
+
+  '@tanstack/router-generator@1.113.0':
+    resolution: {integrity: sha512-r8Yh1Nr3LIf7Nzv388CjXnSB2nooAN+HoRzPUE15O0pxsVXc7ISRQVSXgniJgitxsrqRRbuBLlN1RyvQZpfzFw==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      '@tanstack/react-router': ^1.112.18
     peerDependenciesMeta:
       '@tanstack/react-router':
         optional: true
 
-  '@tanstack/router-plugin@1.108.0':
-    resolution: {integrity: sha512-Mfqq5wzbuFiX1yocdn7j0vOkNit+xhnyC8H6cFJntvD15Y6bH9bNjiBI9gXYBVIa/wgZ7sfT9Ag3eKcTLzy4xQ==}
+  '@tanstack/router-plugin@1.113.0':
+    resolution: {integrity: sha512-i9gMHtSYCPbm2QyDxiIia8mV1MghgE04nuhKIX+1jiMD8rizPpmALuQMwqCC2697/8bjnJ0NB8GUY0UFPv5lGQ==}
     engines: {node: '>=12'}
     peerDependencies:
       '@rsbuild/core': '>=1.0.2'
-      '@tanstack/react-router': ^1.108.0
+      '@tanstack/react-router': ^1.112.18
       vite: '>=5.0.0 || >=6.0.0'
       vite-plugin-solid: ^2.11.2
       webpack: '>=5.92.0'
@@ -695,15 +715,23 @@ packages:
       webpack:
         optional: true
 
-  '@tanstack/router-utils@1.102.2':
-    resolution: {integrity: sha512-Uwl2nbrxhCzviaHHBLNPhSC/OMpZLdOTxTJndUSsXTzWUP4IoQcVmngaIsxi9iriE3ArC1VXuanUAkfGmimNOQ==}
+  '@tanstack/router-utils@1.112.18':
+    resolution: {integrity: sha512-qo6Ac9geasjmt3zfcG73N6PDYqXhIvKO0c2Z41r8al7EBZvjU1eM9DR9nPE6jXu3y2B4/Nd5UiVGvP7/vXUDng==}
     engines: {node: '>=12'}
 
-  '@tanstack/solid-router@1.108.0':
-    resolution: {integrity: sha512-DKtrdy/BHCGvc8wP8xW0tuc8bgA6lPGynbT50Zq8PgYD0ObIUWVHO4kKBwAPBRJQwsesDGdInir1nRMa+8c6iw==}
+  '@tanstack/solid-router-devtools@1.114.0':
+    resolution: {integrity: sha512-pEUY6OE+/Bt0p6vwsmsEOqfUA3RYE6Z+8A4voiDAHibwOypamaGfc8XyO7jS72X6F/i11FkLhkLwSObE/Z+yuQ==}
     engines: {node: '>=12'}
     peerDependencies:
-      solid-js: ^1
+      '@tanstack/router-devtools-core': ^1.114.0
+      '@tanstack/solid-router': ^1.112.18
+      solid-js: ^1.9.5
+
+  '@tanstack/solid-router@1.112.18':
+    resolution: {integrity: sha512-VtVkyDrYEaoAQJLZ4oUofLhJeUy+Om+/iKKALxrfSOOfWUZsXV4xO72E+yxiMiTPpfXqrBdKOKbTXzLY7lizBA==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      solid-js: ^1.9.5
 
   '@tanstack/solid-store@0.7.0':
     resolution: {integrity: sha512-uDQYkUuH3MppitiduZLTEcItkTr8vEJ33jzp2rH2VvlNRMGbuU54GQcqf3dLIlTbZ1/Z2TtIBtBjjl+N/OhwRg==}
@@ -816,6 +844,10 @@ packages:
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -940,6 +972,11 @@ packages:
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
+
+  goober@2.1.16:
+    resolution: {integrity: sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==}
+    peerDependencies:
+      csstype: ^3.0.10
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
@@ -1860,21 +1897,35 @@ snapshots:
     dependencies:
       solid-js: 1.9.5
 
-  '@tanstack/history@1.99.13': {}
-
-  '@tanstack/router-core@1.108.0':
+  '@solidjs/meta@0.29.4(solid-js@1.9.5)':
     dependencies:
-      '@tanstack/history': 1.99.13
+      solid-js: 1.9.5
+
+  '@tanstack/history@1.112.18': {}
+
+  '@tanstack/router-core@1.112.18':
+    dependencies:
+      '@tanstack/history': 1.112.18
       '@tanstack/store': 0.7.0
 
-  '@tanstack/router-generator@1.108.0':
+  '@tanstack/router-devtools-core@1.114.0(@tanstack/router-core@1.112.18)(csstype@3.1.3)(solid-js@1.9.5)(tiny-invariant@1.3.3)':
+    dependencies:
+      '@tanstack/router-core': 1.112.18
+      clsx: 2.1.1
+      goober: 2.1.16(csstype@3.1.3)
+      solid-js: 1.9.5
+      tiny-invariant: 1.3.3
+    optionalDependencies:
+      csstype: 3.1.3
+
+  '@tanstack/router-generator@1.113.0':
     dependencies:
       '@tanstack/virtual-file-routes': 1.99.0
       prettier: 3.5.1
       tsx: 4.19.3
       zod: 3.24.2
 
-  '@tanstack/router-plugin@1.108.0(vite-plugin-solid@2.11.6(solid-js@1.9.5)(vite@6.1.1(jiti@1.21.7)(tsx@4.19.3)(yaml@2.7.0)))(vite@6.1.1(jiti@1.21.7)(tsx@4.19.3)(yaml@2.7.0))':
+  '@tanstack/router-plugin@1.113.0(vite-plugin-solid@2.11.6(solid-js@1.9.5)(vite@6.1.1(jiti@1.21.7)(tsx@4.19.3)(yaml@2.7.0)))(vite@6.1.1(jiti@1.21.7)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.9)
@@ -1882,8 +1933,9 @@ snapshots:
       '@babel/template': 7.26.9
       '@babel/traverse': 7.26.9
       '@babel/types': 7.26.9
-      '@tanstack/router-generator': 1.108.0
-      '@tanstack/router-utils': 1.102.2
+      '@tanstack/router-core': 1.112.18
+      '@tanstack/router-generator': 1.113.0
+      '@tanstack/router-utils': 1.112.18
       '@tanstack/virtual-file-routes': 1.99.0
       '@types/babel__core': 7.20.5
       '@types/babel__template': 7.4.4
@@ -1898,19 +1950,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-utils@1.102.2':
+  '@tanstack/router-utils@1.112.18':
     dependencies:
       '@babel/generator': 7.26.9
       '@babel/parser': 7.26.9
       ansis: 3.15.0
       diff: 7.0.0
 
-  '@tanstack/solid-router@1.108.0(solid-js@1.9.5)':
+  '@tanstack/solid-router-devtools@1.114.0(@tanstack/router-devtools-core@1.114.0(@tanstack/router-core@1.112.18)(csstype@3.1.3)(solid-js@1.9.5)(tiny-invariant@1.3.3))(@tanstack/solid-router@1.112.18(solid-js@1.9.5))(solid-js@1.9.5)':
+    dependencies:
+      '@tanstack/router-devtools-core': 1.114.0(@tanstack/router-core@1.112.18)(csstype@3.1.3)(solid-js@1.9.5)(tiny-invariant@1.3.3)
+      '@tanstack/solid-router': 1.112.18(solid-js@1.9.5)
+      solid-js: 1.9.5
+
+  '@tanstack/solid-router@1.112.18(solid-js@1.9.5)':
     dependencies:
       '@solid-devtools/logger': 0.9.7(solid-js@1.9.5)
       '@solid-primitives/refs': 1.1.0(solid-js@1.9.5)
-      '@tanstack/history': 1.99.13
-      '@tanstack/router-core': 1.108.0
+      '@solidjs/meta': 0.29.4(solid-js@1.9.5)
+      '@tanstack/history': 1.112.18
+      '@tanstack/router-core': 1.112.18
       '@tanstack/solid-store': 0.7.0(solid-js@1.9.5)
       jsesc: 3.1.0
       solid-js: 1.9.5
@@ -2040,6 +2099,8 @@ snapshots:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  clsx@2.1.1: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -2191,6 +2252,10 @@ snapshots:
       path-scurry: 1.11.1
 
   globals@11.12.0: {}
+
+  goober@2.1.16(csstype@3.1.3):
+    dependencies:
+      csstype: 3.1.3
 
   hasown@2.0.2:
     dependencies:

--- a/tanstack-router-file-based/src/routeTree.gen.ts
+++ b/tanstack-router-file-based/src/routeTree.gen.ts
@@ -241,3 +241,58 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRoute
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>();
+
+/* ROUTE_MANIFEST_START
+{
+  "routes": {
+    "__root__": {
+      "filePath": "__root.tsx",
+      "children": [
+        "/",
+        "/_layout",
+        "/posts"
+      ]
+    },
+    "/": {
+      "filePath": "index.tsx"
+    },
+    "/_layout": {
+      "filePath": "_layout.tsx",
+      "children": [
+        "/_layout/_layout-2"
+      ]
+    },
+    "/posts": {
+      "filePath": "posts.tsx",
+      "children": [
+        "/posts/$postId",
+        "/posts/"
+      ]
+    },
+    "/_layout/_layout-2": {
+      "filePath": "_layout/_layout-2.tsx",
+      "parent": "/_layout",
+      "children": [
+        "/_layout/_layout-2/layout-a",
+        "/_layout/_layout-2/layout-b"
+      ]
+    },
+    "/posts/$postId": {
+      "filePath": "posts.$postId.tsx",
+      "parent": "/posts"
+    },
+    "/posts/": {
+      "filePath": "posts.index.tsx",
+      "parent": "/posts"
+    },
+    "/_layout/_layout-2/layout-a": {
+      "filePath": "_layout/_layout-2/layout-a.tsx",
+      "parent": "/_layout/_layout-2"
+    },
+    "/_layout/_layout-2/layout-b": {
+      "filePath": "_layout/_layout-2/layout-b.tsx",
+      "parent": "/_layout/_layout-2"
+    }
+  }
+}
+ROUTE_MANIFEST_END */

--- a/tanstack-router-file-based/src/routes/__root.tsx
+++ b/tanstack-router-file-based/src/routes/__root.tsx
@@ -1,4 +1,5 @@
 import { Link, Outlet, createRootRoute } from '@tanstack/solid-router';
+import { TanStackRouterDevtools } from '@tanstack/solid-router-devtools';
 
 export const Route = createRootRoute({
   component: RootComponent,
@@ -54,6 +55,7 @@ function RootComponent() {
       <hr />
       <Outlet />
       {/* Start rendering router matches */}
+      <TanStackRouterDevtools position="bottom-right" />
     </>
   );
 }


### PR DESCRIPTION
This adds the new `@tanstack/solid-router-devtools` to

- tanstack-router-config-based
- tanstack-router-file-based

