### PR TITLE
Update type in `app.tsx`

### DIFF
--- a/ts-router-file-based/src/app.tsx
+++ b/ts-router-file-based/src/app.tsx
@@ -1,7 +1,7 @@
-import { Suspense, type Component } from 'solid-js';
+import { Suspense, type ParentComponent } from 'solid-js';
 import { A, useLocation } from '@solidjs/router';
 
-const App: Component = (props: { children: Element }) => {
+const App: ParentComponent = (props: { children: Element }) => {
   const location = useLocation();
 
   return (


### PR DESCRIPTION
type `Component` has been replaced with type `ParentComponent`.

it solves a type error in `index.tsx` file at 
`() => <Router root={(props) => <App>{props.children}</App>}>{routes}</Router>,`

"Type '{ children: Element; }' has no properties in common with type 'IntrinsicAttributes'.ts"