### PR TITLE
Fix documentation typos and broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You get:
 - Minimal bundle size
 - All the vite features
 
-### Learn more on the [Solid Website](https://solidjs.com) and come chat with us on our [Discord](https://discord.com/invite/solidjs)
+### Learn more on the [Solid Website](https://www.solidjs.com/) and come chat with us on our [Discord](https://discord.com/invite/solidjs)
 
 ## Get started
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You get:
 
 Those templates dependencies are maintained via [pnpm](https://pnpm.io) via `pnpm up -Lri`.
 
-This is the reason you see a `pnpm-lock.yaml`. That being said, any package manager will work. This file can be safely be removed once you clone a template.
+This is the reason you see a `pnpm-lock.yaml`. That being said, any package manager will work. This file can be safely removed once you clone a template.
 
 These templates are meant to be used as is via the [degit](https://github.com/Rich-Harris/degit) utility.
 

--- a/solid-start-v1/with-authjs/README.md
+++ b/solid-start-v1/with-authjs/README.md
@@ -10,7 +10,7 @@ Everything you need to build an [AuthJS](https://authjs.dev/) authenticated Soli
 
 This will start a production server on port `3000`.
 
-### Enviroment Variables
+### Environment Variables
 
 - `DISCORD_ID`=
 - `DISCORD_SECRET`=

--- a/solid-start-v1/with-mdx/src/routes/[...404].mdx
+++ b/solid-start-v1/with-mdx/src/routes/[...404].mdx
@@ -4,4 +4,4 @@ import { HttpStatusCode } from "@solidjs/start";
 
 # Page Not Found
 
-Visit [https://solidjs.com](https://solidjs.com) to learn how to build Solid apps.
+Visit [https://www.solidjs.com/](https://www.solidjs.com/) to learn how to build Solid apps.

--- a/solid-start-v1/with-mdx/src/routes/index.mdx
+++ b/solid-start-v1/with-mdx/src/routes/index.mdx
@@ -4,4 +4,4 @@ import Counter from "~/components/Counter";
 
 <Counter />
 
-Visit [https://solidjs.com](https://solidjs.com) to learn how to build Solid apps.
+Visit [https://www.solidjs.com/](https://www.solidjs.com/) to learn how to build Solid apps.

--- a/solid-start-v1/with-tailwindcss/src/routes/[...404].tsx
+++ b/solid-start-v1/with-tailwindcss/src/routes/[...404].tsx
@@ -6,7 +6,7 @@ export default function NotFound() {
       <h1 class="max-6-xs text-6xl text-sky-700 font-thin uppercase my-16">Not Found</h1>
       <p class="mt-8">
         Visit{" "}
-        <a href="https://solidjs.com" target="_blank" class="text-sky-600 hover:underline">
+        <a href="https://www.solidjs.com/" target="_blank" class="text-sky-600 hover:underline">
           solidjs.com
         </a>{" "}
         to learn how to build Solid apps.

--- a/solid-start-v1/with-tailwindcss/src/routes/about.tsx
+++ b/solid-start-v1/with-tailwindcss/src/routes/about.tsx
@@ -8,7 +8,7 @@ export default function About() {
       <Counter />
       <p class="mt-8">
         Visit{" "}
-        <a href="https://solidjs.com" target="_blank" class="text-sky-600 hover:underline">
+        <a href="https://www.solidjs.com/" target="_blank" class="text-sky-600 hover:underline">
           solidjs.com
         </a>{" "}
         to learn how to build Solid apps.

--- a/solid-start-v1/with-tailwindcss/src/routes/index.tsx
+++ b/solid-start-v1/with-tailwindcss/src/routes/index.tsx
@@ -8,7 +8,7 @@ export default function Home() {
       <Counter />
       <p class="mt-8">
         Visit{" "}
-        <a href="https://solidjs.com" target="_blank" class="text-sky-600 hover:underline">
+        <a href="https://www.solidjs.com/" target="_blank" class="text-sky-600 hover:underline">
           solidjs.com
         </a>{" "}
         to learn how to build Solid apps.

--- a/solid-start-v1/with-unocss/src/routes/[...404].tsx
+++ b/solid-start-v1/with-unocss/src/routes/[...404].tsx
@@ -9,7 +9,7 @@ export default function NotFound() {
       <p class="mt-8">
         Visit{" "}
         <a
-          href="https://solidjs.com"
+          href="https://www.solidjs.com/"
           target="_blank"
           class="text-sky-600 hover:underline"
         >

--- a/solid-start-v1/with-unocss/src/routes/about.tsx
+++ b/solid-start-v1/with-unocss/src/routes/about.tsx
@@ -11,7 +11,7 @@ export default function About() {
       <p class="mt-8">
         Visit{" "}
         <a
-          href="https://solidjs.com"
+          href="https://www.solidjs.com/"
           target="_blank"
           class="text-sky-600 hover:underline"
         >

--- a/solid-start-v1/with-unocss/src/routes/index.tsx
+++ b/solid-start-v1/with-unocss/src/routes/index.tsx
@@ -13,7 +13,7 @@ export default function Home() {
       <p class="mt-8">
         Visit{" "}
         <a
-          href="https://solidjs.com"
+          href="https://www.solidjs.com/"
           target="_blank"
           class="text-sky-600 hover:underline"
         >

--- a/solid-start-v1/with-vitest/src/routes/index.tsx
+++ b/solid-start-v1/with-vitest/src/routes/index.tsx
@@ -8,7 +8,7 @@ export default function Home() {
       <Counter />
       <p>
         Visit{" "}
-        <a href="https://solidjs.com" target="_blank">
+        <a href="https://www.solidjs.com/" target="_blank">
           solidjs.com
         </a>{" "}
         to learn how to build Solid apps.

--- a/solid-start-v2/with-authjs/README.md
+++ b/solid-start-v2/with-authjs/README.md
@@ -10,7 +10,7 @@ Everything you need to build an [AuthJS](https://authjs.dev/) authenticated Soli
 
 This will start a production server on port `3000`.
 
-### Enviroment Variables
+### Environment Variables
 
 - `DISCORD_ID`=
 - `DISCORD_SECRET`=

--- a/solid-start-v2/with-mdx/src/routes/[...404].mdx
+++ b/solid-start-v2/with-mdx/src/routes/[...404].mdx
@@ -4,4 +4,4 @@ import { HttpStatusCode } from "@solidjs/start";
 
 # Page Not Found
 
-Visit [https://solidjs.com](https://solidjs.com) to learn how to build Solid apps.
+Visit [https://www.solidjs.com/](https://www.solidjs.com/) to learn how to build Solid apps.

--- a/solid-start-v2/with-mdx/src/routes/index.mdx
+++ b/solid-start-v2/with-mdx/src/routes/index.mdx
@@ -4,4 +4,4 @@ import Counter from "~/components/Counter";
 
 <Counter />
 
-Visit [https://solidjs.com](https://solidjs.com) to learn how to build Solid apps.
+Visit [https://www.solidjs.com/](https://www.solidjs.com/) to learn how to build Solid apps.

--- a/solid-start-v2/with-tailwindcss/src/routes/[...404].tsx
+++ b/solid-start-v2/with-tailwindcss/src/routes/[...404].tsx
@@ -6,7 +6,7 @@ export default function NotFound() {
       <h1 class="max-6-xs text-6xl text-sky-700 font-thin uppercase my-16">Not Found</h1>
       <p class="mt-8">
         Visit{" "}
-        <a href="https://solidjs.com" target="_blank" class="text-sky-600 hover:underline">
+        <a href="https://www.solidjs.com/" target="_blank" class="text-sky-600 hover:underline">
           solidjs.com
         </a>{" "}
         to learn how to build Solid apps.

--- a/solid-start-v2/with-tailwindcss/src/routes/about.tsx
+++ b/solid-start-v2/with-tailwindcss/src/routes/about.tsx
@@ -8,7 +8,7 @@ export default function About() {
       <Counter />
       <p class="mt-8">
         Visit{" "}
-        <a href="https://solidjs.com" target="_blank" class="text-sky-600 hover:underline">
+        <a href="https://www.solidjs.com/" target="_blank" class="text-sky-600 hover:underline">
           solidjs.com
         </a>{" "}
         to learn how to build Solid apps.

--- a/solid-start-v2/with-tailwindcss/src/routes/index.tsx
+++ b/solid-start-v2/with-tailwindcss/src/routes/index.tsx
@@ -8,7 +8,7 @@ export default function Home() {
       <Counter />
       <p class="mt-8">
         Visit{" "}
-        <a href="https://solidjs.com" target="_blank" class="text-sky-600 hover:underline">
+        <a href="https://www.solidjs.com/" target="_blank" class="text-sky-600 hover:underline">
           solidjs.com
         </a>{" "}
         to learn how to build Solid apps.

--- a/solid-start-v2/with-unocss/src/routes/[...404].tsx
+++ b/solid-start-v2/with-unocss/src/routes/[...404].tsx
@@ -9,7 +9,7 @@ export default function NotFound() {
       <p class="mt-8">
         Visit{" "}
         <a
-          href="https://solidjs.com"
+          href="https://www.solidjs.com/"
           target="_blank"
           class="text-sky-600 hover:underline"
         >

--- a/solid-start-v2/with-unocss/src/routes/about.tsx
+++ b/solid-start-v2/with-unocss/src/routes/about.tsx
@@ -11,7 +11,7 @@ export default function About() {
       <p class="mt-8">
         Visit{" "}
         <a
-          href="https://solidjs.com"
+          href="https://www.solidjs.com/"
           target="_blank"
           class="text-sky-600 hover:underline"
         >

--- a/solid-start-v2/with-unocss/src/routes/index.tsx
+++ b/solid-start-v2/with-unocss/src/routes/index.tsx
@@ -13,7 +13,7 @@ export default function Home() {
       <p class="mt-8">
         Visit{" "}
         <a
-          href="https://solidjs.com"
+          href="https://www.solidjs.com/"
           target="_blank"
           class="text-sky-600 hover:underline"
         >

--- a/solid-start-v2/with-vitest/src/routes/index.tsx
+++ b/solid-start-v2/with-vitest/src/routes/index.tsx
@@ -8,7 +8,7 @@ export default function Home() {
       <Counter />
       <p>
         Visit{" "}
-        <a href="https://solidjs.com" target="_blank">
+        <a href="https://www.solidjs.com/" target="_blank">
           solidjs.com
         </a>{" "}
         to learn how to build Solid apps.

--- a/vanilla/bare/README.md
+++ b/vanilla/bare/README.md
@@ -2,7 +2,7 @@
 
 Those templates dependencies are maintained via [pnpm](https://pnpm.io) via `pnpm up -Lri`.
 
-This is the reason you see a `pnpm-lock.yaml`. That being said, any package manager will work. This file can be safely be removed once you clone a template.
+This is the reason you see a `pnpm-lock.yaml`. That being said, any package manager will work. This file can be safely removed once you clone a template.
 
 ```bash
 $ npm install # or pnpm install or yarn install

--- a/vanilla/bare/README.md
+++ b/vanilla/bare/README.md
@@ -8,7 +8,7 @@ This is the reason you see a `pnpm-lock.yaml`. That being said, any package mana
 $ npm install # or pnpm install or yarn install
 ```
 
-### Learn more on the [Solid Website](https://solidjs.com) and come chat with us on our [Discord](https://discord.com/invite/solidjs)
+### Learn more on the [Solid Website](https://www.solidjs.com/) and come chat with us on our [Discord](https://discord.com/invite/solidjs)
 
 ## Available Scripts
 

--- a/vanilla/basic/README.md
+++ b/vanilla/basic/README.md
@@ -2,7 +2,7 @@
 
 Those templates dependencies are maintained via [pnpm](https://pnpm.io) via `pnpm up -Lri`.
 
-This is the reason you see a `pnpm-lock.yaml`. That being said, any package manager will work. This file can be safely be removed once you clone a template.
+This is the reason you see a `pnpm-lock.yaml`. That being said, any package manager will work. This file can be safely removed once you clone a template.
 
 ```bash
 $ npm install # or pnpm install or yarn install

--- a/vanilla/basic/README.md
+++ b/vanilla/basic/README.md
@@ -8,7 +8,7 @@ This is the reason you see a `pnpm-lock.yaml`. That being said, any package mana
 $ npm install # or pnpm install or yarn install
 ```
 
-### Learn more on the [Solid Website](https://solidjs.com) and come chat with us on our [Discord](https://discord.com/invite/solidjs)
+### Learn more on the [Solid Website](https://www.solidjs.com/) and come chat with us on our [Discord](https://discord.com/invite/solidjs)
 
 ## Available Scripts
 

--- a/vanilla/with-bootstrap/README.md
+++ b/vanilla/with-bootstrap/README.md
@@ -2,7 +2,7 @@
 
 Those templates dependencies are maintained via [pnpm](https://pnpm.io) via `pnpm up -Lri`.
 
-This is the reason you see a `pnpm-lock.yaml`. That being said, any package manager will work. This file can be safely be removed once you clone a template.
+This is the reason you see a `pnpm-lock.yaml`. That being said, any package manager will work. This file can be safely removed once you clone a template.
 
 ```bash
 $ npm install # or pnpm install or yarn install

--- a/vanilla/with-bootstrap/README.md
+++ b/vanilla/with-bootstrap/README.md
@@ -8,7 +8,7 @@ This is the reason you see a `pnpm-lock.yaml`. That being said, any package mana
 $ npm install # or pnpm install or yarn install
 ```
 
-### Learn more on the [Solid Website](https://solidjs.com) and come chat with us on our [Discord](https://discord.com/invite/solidjs)
+### Learn more on the [Solid Website](https://www.solidjs.com/) and come chat with us on our [Discord](https://discord.com/invite/solidjs)
 
 ## Available Scripts
 

--- a/vanilla/with-sass/README.md
+++ b/vanilla/with-sass/README.md
@@ -2,7 +2,7 @@
 
 Those templates dependencies are maintained via [pnpm](https://pnpm.io) via `pnpm up -Lri`.
 
-This is the reason you see a `pnpm-lock.yaml`. That being said, any package manager will work. This file can be safely be removed once you clone a template.
+This is the reason you see a `pnpm-lock.yaml`. That being said, any package manager will work. This file can be safely removed once you clone a template.
 
 ```bash
 $ npm install # or pnpm install or yarn install

--- a/vanilla/with-sass/README.md
+++ b/vanilla/with-sass/README.md
@@ -8,7 +8,7 @@ This is the reason you see a `pnpm-lock.yaml`. That being said, any package mana
 $ npm install # or pnpm install or yarn install
 ```
 
-### Learn more on the [Solid Website](https://solidjs.com) and come chat with us on our [Discord](https://discord.com/invite/solidjs)
+### Learn more on the [Solid Website](https://www.solidjs.com/) and come chat with us on our [Discord](https://discord.com/invite/solidjs)
 
 ## Available Scripts
 

--- a/vanilla/with-solid-router/README.md
+++ b/vanilla/with-solid-router/README.md
@@ -2,7 +2,7 @@
 
 Those templates dependencies are maintained via [pnpm](https://pnpm.io) via `pnpm up -Lri`.
 
-This is the reason you see a `pnpm-lock.yaml`. That being said, any package manager will work. This file can be safely be removed once you clone a template.
+This is the reason you see a `pnpm-lock.yaml`. That being said, any package manager will work. This file can be safely removed once you clone a template.
 
 ```bash
 $ npm install # or pnpm install or yarn install

--- a/vanilla/with-solid-router/README.md
+++ b/vanilla/with-solid-router/README.md
@@ -15,7 +15,7 @@ It also showcase how the router and Suspense work together to parallelize data f
 
 You can learn more about it on the [`@solidjs/router` repository](https://github.com/solidjs/solid-router)
 
-### Learn more on the [Solid Website](https://solidjs.com) and come chat with us on our [Discord](https://discord.com/invite/solidjs)
+### Learn more on the [Solid Website](https://www.solidjs.com/) and come chat with us on our [Discord](https://discord.com/invite/solidjs)
 
 ## Available Scripts
 

--- a/vanilla/with-tailwindcss/README.md
+++ b/vanilla/with-tailwindcss/README.md
@@ -2,7 +2,7 @@
 
 Those templates dependencies are maintained via [pnpm](https://pnpm.io) via `pnpm up -Lri`.
 
-This is the reason you see a `pnpm-lock.yaml`. That being said, any package manager will work. This file can be safely be removed once you clone a template.
+This is the reason you see a `pnpm-lock.yaml`. That being said, any package manager will work. This file can be safely removed once you clone a template.
 
 ```bash
 $ npm install # or pnpm install or yarn install

--- a/vanilla/with-tailwindcss/README.md
+++ b/vanilla/with-tailwindcss/README.md
@@ -8,7 +8,7 @@ This is the reason you see a `pnpm-lock.yaml`. That being said, any package mana
 $ npm install # or pnpm install or yarn install
 ```
 
-### Learn more on the [Solid Website](https://solidjs.com) and come chat with us on our [Discord](https://discord.com/invite/solidjs)
+### Learn more on the [Solid Website](https://www.solidjs.com/) and come chat with us on our [Discord](https://discord.com/invite/solidjs)
 
 ## Available Scripts
 

--- a/vanilla/with-unocss/README.md
+++ b/vanilla/with-unocss/README.md
@@ -2,7 +2,7 @@
 
 Those templates dependencies are maintained via [pnpm](https://pnpm.io) via `pnpm up -Lri`.
 
-This is the reason you see a `pnpm-lock.yaml`. That being said, any package manager will work. This file can be safely be removed once you clone a template.
+This is the reason you see a `pnpm-lock.yaml`. That being said, any package manager will work. This file can be safely removed once you clone a template.
 
 ```bash
 $ npm install # or pnpm install or yarn install

--- a/vanilla/with-unocss/README.md
+++ b/vanilla/with-unocss/README.md
@@ -8,7 +8,7 @@ This is the reason you see a `pnpm-lock.yaml`. That being said, any package mana
 $ npm install # or pnpm install or yarn install
 ```
 
-### Learn more on the [Solid Website](https://solidjs.com) and come chat with us on our [Discord](https://discord.com/invite/solidjs)
+### Learn more on the [Solid Website](https://www.solidjs.com/) and come chat with us on our [Discord](https://discord.com/invite/solidjs)
 
 ## Available Scripts
 

--- a/vanilla/with-vite-plugin-pages/README.md
+++ b/vanilla/with-vite-plugin-pages/README.md
@@ -2,7 +2,7 @@
 
 Those templates dependencies are maintained via [pnpm](https://pnpm.io) via `pnpm up -Lri`.
 
-This is the reason you see a `pnpm-lock.yaml`. That being said, any package manager will work. This file can be safely be removed once you clone a template.
+This is the reason you see a `pnpm-lock.yaml`. That being said, any package manager will work. This file can be safely removed once you clone a template.
 
 ```bash
 $ npm install # or pnpm install or yarn install

--- a/vanilla/with-vite-plugin-pages/README.md
+++ b/vanilla/with-vite-plugin-pages/README.md
@@ -15,7 +15,7 @@ It also showcase how the router and Suspense work together to parallelize data f
 
 You can learn more about it on the [`@solidjs/router` repository](https://github.com/solidjs/solid-router)
 
-### Learn more on the [Solid Website](https://solidjs.com) and come chat with us on our [Discord](https://discord.com/invite/solidjs)
+### Learn more on the [Solid Website](https://www.solidjs.com/) and come chat with us on our [Discord](https://discord.com/invite/solidjs)
 
 ## Available Scripts
 


### PR DESCRIPTION
# What Changed

Fixed several documentation and readability issues across multiple README files:

- Removed the duplicated be in:
`This file can be safely be removed once you clone a template.`
so it now reads:
`This file can be safely removed once you clone a template.`

- Updated SolidJS website links from:
https://solidjs.com
to:
https://www.solidjs.com/
to ensure redirects work properly.

- Corrected instances of Enviroment to Environment.

## Why

Minor documentation and readability improvements.