### PR TITLE
Fix Safari dev session cookies in SolidStart v2 templates

### DIFF
--- a/solid-start-v2/with-auth/src/auth/server.ts
+++ b/solid-start-v2/with-auth/src/auth/server.ts
@@ -8,9 +8,18 @@ export interface Session {
   email: string;
 }
 
+const SESSION_COOKIE_NAME = "solid_start_auth_session";
+
 export const getSession = () =>
   useSession<Session>({
-    password: process.env.SESSION_SECRET ?? "default_password_which_should_be_long_enough"
+    name: SESSION_COOKIE_NAME,
+    password: process.env.SESSION_SECRET ?? "default_password_which_should_be_long_enough",
+    cookie: {
+      httpOnly: true,
+      path: "/",
+      sameSite: "lax",
+      secure: process.env.NODE_ENV === "production"
+    }
   });
 
 export async function createSession(user: Session, redirectTo?: string) {

--- a/solid-start-v2/with-drizzle/src/api/server.ts
+++ b/solid-start-v2/with-drizzle/src/api/server.ts
@@ -5,6 +5,8 @@ import { eq } from "drizzle-orm";
 import { db } from "./db";
 import { Users } from "../../drizzle/schema";
 
+const SESSION_COOKIE_NAME = "solid_start_drizzle_session";
+
 function validateUsername(username: unknown) {
   if (typeof username !== "string" || username.length < 3) {
     return `Usernames must be at least 3 characters long`;
@@ -31,7 +33,14 @@ async function register(username: string, password: string) {
 
 function getSession() {
   return useSession({
-    password: process.env.SESSION_SECRET ?? "areallylongsecretthatyoushouldreplace"
+    name: SESSION_COOKIE_NAME,
+    password: process.env.SESSION_SECRET ?? "areallylongsecretthatyoushouldreplace",
+    cookie: {
+      httpOnly: true,
+      path: "/",
+      sameSite: "lax",
+      secure: process.env.NODE_ENV === "production"
+    }
   });
 }
 

--- a/solid-start-v2/with-prisma/src/lib/server.ts
+++ b/solid-start-v2/with-prisma/src/lib/server.ts
@@ -1,6 +1,8 @@
 import { useSession } from "@solidjs/start/http";
 import { db } from "./db";
 
+const SESSION_COOKIE_NAME = "solid_start_prisma_session";
+
 export function validateUsername(username: unknown) {
   if (typeof username !== "string" || username.length < 3) {
     return `Usernames must be at least 3 characters long`;
@@ -36,6 +38,13 @@ export async function register(username: string, password: string) {
 
 export function getSession() {
   return useSession({
-    password: process.env.SESSION_SECRET ?? "areallylongsecretthatyoushouldreplace"
+    name: SESSION_COOKIE_NAME,
+    password: process.env.SESSION_SECRET ?? "areallylongsecretthatyoushouldreplace",
+    cookie: {
+      httpOnly: true,
+      path: "/",
+      sameSite: "lax",
+      secure: process.env.NODE_ENV === "production"
+    }
   });
 }


### PR DESCRIPTION
## Problem

The SolidStart v2 `with-auth`, `with-drizzle`, and `with-prisma` templates rely on H3's default session cookie settings. H3 sets session cookies as `Secure` by default, which is correct for HTTPS but causes problems in Safari during local development on plain `http://localhost`.

In Safari, this makes login appear broken: the sign-in request succeeds, but the session cookie is not preserved across reloads, so the user is sent back to the login flow. That creates some confusion as these templates do not work.

## Fix

Configure the H3 session cookie explicitly in the affected templates:

- keep `HttpOnly`
- keep `Path=/`
- use `SameSite=Lax`
- set `Secure` only in production
- use a template-specific cookie name to avoid localhost collisions

(I also checked how Better Auth handles the same local-dev case)
Production deployments still receive `Secure` cookies because `secure` is enabled when `NODE_ENV === "production"`.

H3 session cookie options are configurable through `useSession`:  
https://h3.dev/examples/handle-session#options

## Testing

Before fix in Safari, the session cookie was returned with `Secure` on `http://localhost`, and login was not preserved after reload:

<img width="1081" height="213" alt="Screenshot 2026-05-17 at 01 52 35" src="https://github.com/user-attachments/assets/498d927c-8aca-4f39-88dd-a7b752b09c93" />

Tested the updated `with-drizzle` template with:
```
npx degit obask/templates-solid/solid-start-v2/with-drizzle#fix/solidstart-v2-dev-session-cookies my-test-project1
cd my-test-project1
pnpm i
pnpm approve-builds
pnpm dev
```
After fix, Safari stores the session cookie without Secure in local dev:

<img width="1153" height="126" alt="Screenshot 2026-05-17 at 01 56 33" src="https://github.com/user-attachments/assets/fbc80544-715d-44ea-965a-d7a48400ee9b" />
I also reloaded the page and confirmed the login session is preserved.

Note: I initially tested this while experimenting with SSR disabled, but the fix works with SSR enabled as well.
