### PR TITLE
reorder tw4 vite plugin

### DIFF
--- a/solid-start-v2/with-auth/vite.config.ts
+++ b/solid-start-v2/with-auth/vite.config.ts
@@ -5,10 +5,10 @@ import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
   plugins: [
+    tailwindcss(),
     solidStart({
       ssr: true
     }),
-    tailwindcss(),
     nitro()
   ]
 });

--- a/solid-start-v2/with-tailwindcss/vite.config.ts
+++ b/solid-start-v2/with-tailwindcss/vite.config.ts
@@ -5,8 +5,8 @@ import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
   plugins: [
-    solidStart(),
     tailwindcss(),
+    solidStart(),
     nitro()
   ]
 });

--- a/vanilla/with-tailwindcss/vite.config.ts
+++ b/vanilla/with-tailwindcss/vite.config.ts
@@ -4,7 +4,7 @@ import solidPlugin from 'vite-plugin-solid';
 import devtools from 'solid-devtools/vite';
 
 export default defineConfig({
-  plugins: [devtools(), solidPlugin(), tailwindcss()],
+  plugins: [ tailwindcss(),devtools(), solidPlugin()],
   server: {
     port: 3000,
   },


### PR DESCRIPTION
Fix: Hot reloading not working with tw4.
Tailwind plugin must be loaded before solid to make it work.