### PR TITLE
fix: replace non-existent `vite start` with `node .output/server/index.mjs` in solid-start-v2 templates

### DIFF
--- a/solid-start-v2/bare/package.json
+++ b/solid-start-v2/bare/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
-    "start": "vite start",
+    "start": "node .output/server/index.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/solid-start-v2/basic/package.json
+++ b/solid-start-v2/basic/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
-    "start": "vite start",
+    "start": "node .output/server/index.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/solid-start-v2/with-auth/package.json
+++ b/solid-start-v2/with-auth/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
-    "start": "vite start",
+    "start": "node .output/server/index.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/solid-start-v2/with-authjs/package.json
+++ b/solid-start-v2/with-authjs/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
-    "start": "vite start",
+    "start": "node .output/server/index.mjs",
     "lint": "eslint --fix \"**/*.{ts,tsx,js,jsx}\"",
     "preview": "vite preview"
   },

--- a/solid-start-v2/with-drizzle/package.json
+++ b/solid-start-v2/with-drizzle/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
-    "start": "vite start",
+    "start": "node .output/server/index.mjs",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/solid-start-v2/with-mdx/package.json
+++ b/solid-start-v2/with-mdx/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
-    "start": "vite start",
+    "start": "node .output/server/index.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/solid-start-v2/with-prisma/package.json
+++ b/solid-start-v2/with-prisma/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
-    "start": "vite start",
+    "start": "node .output/server/index.mjs",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/solid-start-v2/with-solid-styled/package.json
+++ b/solid-start-v2/with-solid-styled/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
-    "start": "vite start",
+    "start": "node .output/server/index.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/solid-start-v2/with-solidbase/package.json
+++ b/solid-start-v2/with-solidbase/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
-    "start": "vite start",
+    "start": "node .output/server/index.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/solid-start-v2/with-strict-csp/package.json
+++ b/solid-start-v2/with-strict-csp/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
-    "start": "vite start",
+    "start": "node .output/server/index.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/solid-start-v2/with-tailwindcss/package.json
+++ b/solid-start-v2/with-tailwindcss/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
-    "start": "vite start",
+    "start": "node .output/server/index.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/solid-start-v2/with-tanstack-router/package.json
+++ b/solid-start-v2/with-tanstack-router/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
-    "start": "vite start",
+    "start": "node .output/server/index.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/solid-start-v2/with-trpc/package.json
+++ b/solid-start-v2/with-trpc/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
-    "start": "vite start",
+    "start": "node .output/server/index.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/solid-start-v2/with-unocss/package.json
+++ b/solid-start-v2/with-unocss/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
-    "start": "vite start",
+    "start": "node .output/server/index.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/solid-start-v2/with-vitest/package.json
+++ b/solid-start-v2/with-vitest/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
-    "start": "vite start",
+    "start": "node .output/server/index.mjs",
     "test": "vitest run",
     "test-watch": "vitest",
     "test-ui": "vitest --ui",


### PR DESCRIPTION
Fixes solidjs/solid-start#2138

## What is the current behavior?

All `solid-start-v2` templates ship `"start": "vite start"`, but `vite start` is not a Vite command. Vite's CLI parses `start` as the **root directory** argument, so it silently launches a plain dev server on port 5173 rooted at a nonexistent `./start` folder — without ever loading the project's `vite.config.ts`. The terminal shows a running server, but the browser gets nothing. This made freshly scaffolded projects (`pnpm create solid --start --v2`) undeployable via `pnpm run start`.

## What is the new behavior?

`"start": "node .output/server/index.mjs"` in all 15 `solid-start-v2` templates. Every v2 template uses the nitro plugin, whose `vite build` outputs a Node server at `.output/server/index.mjs` (nitro itself prints "You can preview this build using node .output/server/index.mjs" at the end of the build).

Verified against solid-start's `basic` and `todomvc` fixtures: `vite build` followed by `node .output/server/index.mjs` serves the app on port 3000 with HTTP 200 and fully server-rendered HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)