### PR TITLE
fix(with-tanstack-router): use per-request router for SSR

### DIFF
--- a/solid-start-v2/with-tanstack-router/src/app.tsx
+++ b/solid-start-v2/with-tanstack-router/src/app.tsx
@@ -1,8 +1,12 @@
-import { router } from "./router";
-import { RouterProvider } from "@tanstack/solid-router";
+import { router } from './router';
+import { RouterProvider } from '@tanstack/solid-router';
+import { getRequestEvent } from 'solid-js/web';
 
-import "./app.css";
+import './app.css';
 
 export default function App() {
-  return <RouterProvider router={router} />;
+  const event = getRequestEvent();
+  const requestRouter = event?.locals.router as typeof router | undefined;
+
+  return <RouterProvider router={requestRouter ?? router} />;
 }

--- a/solid-start-v2/with-tanstack-router/src/entry-server.tsx
+++ b/solid-start-v2/with-tanstack-router/src/entry-server.tsx
@@ -1,19 +1,22 @@
 // @refresh reload
-import { createHandler, FetchEvent, StartServer } from "@solidjs/start/server";
-import { createMemoryHistory } from "@tanstack/solid-router";
-import { router } from "./router";
+import { createHandler, FetchEvent, StartServer } from '@solidjs/start/server';
+import { createMemoryHistory } from '@tanstack/solid-router';
+import { createRouter } from './router';
 
 const routerLoad = async (event: FetchEvent) => {
   const url = new URL(event.request.url);
-  const path = url.href.replace(url.origin, "");
+  const path = url.href.replace(url.origin, '');
 
-  router.update({
+  const requestRouter = createRouter();
+  event.locals.router = requestRouter;
+
+  requestRouter.update({
     history: createMemoryHistory({
-      initialEntries: [path]
-    })
+      initialEntries: [path],
+    }),
   });
 
-  await router.load();
+  await requestRouter.load();
 };
 
 export default createHandler(
@@ -23,7 +26,10 @@ export default createHandler(
         <html lang="en">
           <head>
             <meta charset="utf-8" />
-            <meta name="viewport" content="width=device-width, initial-scale=1" />
+            <meta
+              name="viewport"
+              content="width=device-width, initial-scale=1"
+            />
             <link rel="icon" href="/favicon.ico" />
             {assets}
           </head>
@@ -36,5 +42,5 @@ export default createHandler(
     />
   ),
   undefined,
-  routerLoad
+  routerLoad,
 );


### PR DESCRIPTION
## Summary

Closes #268.

The `solid-start-v2/with-tanstack-router` template shared a single module-level router instance across **all SSR requests**. Under concurrency this leaks match state and loader data between requests — deterministically, once any route has an async loader. The shipped demo hides the leak only because its routes are static with no loaders.

This PR keeps SSR but makes the server-side router **per-request**.

## Changes

- **`entry-server.tsx`** — `routerLoad` now calls `createRouter()` (the factory) once per request and stashes the instance on `event.locals.router`, instead of mutating the shared singleton.
- **`app.tsx`** — reads the per-request router back via `getRequestEvent()?.locals.router`, falling back to the singleton for CSR.
- **`router.tsx`** — unchanged. It already exports the `createRouter()` factory. The module-level singleton export (`router`) is retained as the **CSR fallback**, since the browser shares no state across requests.

## Why a per-request router?

A router instance holds its match cache and loader results. On `@solidjs/start` v2 (Nitro/h3) concurrent requests run on one event loop, so two requests sharing one router can commit one another's data — including user-scoped loader data. This reproduces 100% of the time once a route has an async loader (reproducer in #268).

CSR is unaffected: each browser tab is an isolated runtime that never shares a router across requests, so the singleton is safe there and is kept as the fallback.

## Why the server router never leaks to the client

`getRequestEvent` resolves to a no-op returning `undefined` in the client bundle (`solid-js/web` ships `voidFn as getRequestEvent`), so `getRequestEvent()?.locals.router` short-circuits to the singleton in the browser. The server's router object never crosses the boundary; only the current request's dehydrated state is serialized into the HTML via `$_TSR`, as before.

## Verification

- `@solidjs/start@2.0.0` (stable): `GET /` and `GET /about` return **200** in both `dev` and `build && start`.
- Each request now builds its own router with its own match cache, removing the shared mutable state that produced the leak in #268. I'll re-run the reproducer from #268 against this patch and post the before/after numbers.

## Notes

- This addresses the structural concern from #268 (the 500 was already fixed upstream by `createHandler` re-accepting the `routerLoad` arg on stable).
- Open to the maintainers' preferred naming (`createRouter` vs `getRouter`) and to splitting/combining commits as desired.
