### PR TITLE
Fix v2 build instructions in solid-start-v2 template READMEs

### DIFF
--- a/solid-start-v2/bare/README.md
+++ b/solid-start-v2/bare/README.md
@@ -25,6 +25,6 @@ npm run dev -- --open
 
 ## Building
 
-Solid apps are built with _presets_, which optimise your project for deployment to different environments.
+Solid apps are built with Nitro _presets_, which optimise your project for deployment to different environments.
 
-By default, `npm run build` will generate a Node app that you can run with `npm start`. To use a different preset, add it to the `devDependencies` in `package.json` and specify in your `app.config.js`.
+By default, `npm run build` will generate a Node app under `.output` that you can run with `npm start`. To use a different preset, set it on the `nitro()` plugin in your `vite.config.ts`.

--- a/solid-start-v2/basic/README.md
+++ b/solid-start-v2/basic/README.md
@@ -25,6 +25,6 @@ npm run dev -- --open
 
 ## Building
 
-Solid apps are built with _presets_, which optimise your project for deployment to different environments.
+Solid apps are built with Nitro _presets_, which optimise your project for deployment to different environments.
 
-By default, `npm run build` will generate a Node app that you can run with `npm start`. To use a different preset, add it to the `devDependencies` in `package.json` and specify in your `app.config.js`.
+By default, `npm run build` will generate a Node app under `.output` that you can run with `npm start`. To use a different preset, set it on the `nitro()` plugin in your `vite.config.ts`.

--- a/solid-start-v2/with-drizzle/README.md
+++ b/solid-start-v2/with-drizzle/README.md
@@ -25,6 +25,6 @@ npm run dev
 
 ## Building
 
-Solid apps are built with _adapters_, which optimise your project for deployment to different environments.
+Solid apps are built with Nitro _presets_, which optimise your project for deployment to different environments.
 
-By default, `npm run build` will generate a Node app that you can run with `npm start`. To use a different adapter, add it to the `devDependencies` in `package.json` and specify in your `app.config.js`.
+By default, `npm run build` will generate a Node app under `.output` that you can run with `npm start`. To use a different preset, set it on the `nitro()` plugin in your `vite.config.ts`.

--- a/solid-start-v2/with-mdx/README.md
+++ b/solid-start-v2/with-mdx/README.md
@@ -25,6 +25,6 @@ npm run dev -- --open
 
 ## Building
 
-Solid apps are built with _presets_, which optimise your project for deployment to different environments.
+Solid apps are built with Nitro _presets_, which optimise your project for deployment to different environments.
 
-By default, `npm run build` will generate a Node app that you can run with `npm start`. To use a different preset, add it to the `devDependencies` in `package.json` and specify in your `app.config.js`.
+By default, `npm run build` will generate a Node app under `.output` that you can run with `npm start`. To use a different preset, set it on the `nitro()` plugin in your `vite.config.ts`.

--- a/solid-start-v2/with-prisma/README.md
+++ b/solid-start-v2/with-prisma/README.md
@@ -25,6 +25,6 @@ npm run dev -- --open
 
 ## Building
 
-Solid apps are built with _presets_, which optimise your project for deployment to different environments.
+Solid apps are built with Nitro _presets_, which optimise your project for deployment to different environments.
 
-By default, `npm run build` will generate a Node app that you can run with `npm start`. To use a different preset, add it to the `devDependencies` in `package.json` and specify in your `app.config.js`.
+By default, `npm run build` will generate a Node app under `.output` that you can run with `npm start`. To use a different preset, set it on the `nitro()` plugin in your `vite.config.ts`.

--- a/solid-start-v2/with-solid-styled/README.md
+++ b/solid-start-v2/with-solid-styled/README.md
@@ -25,6 +25,6 @@ npm run dev -- --open
 
 ## Building
 
-Solid apps are built with _presets_, which optimise your project for deployment to different environments.
+Solid apps are built with Nitro _presets_, which optimise your project for deployment to different environments.
 
-By default, `npm run build` will generate a Node app that you can run with `npm start`. To use a different preset, add it to the `devDependencies` in `package.json` and specify in your `app.config.js`.
+By default, `npm run build` will generate a Node app under `.output` that you can run with `npm start`. To use a different preset, set it on the `nitro()` plugin in your `vite.config.ts`.

--- a/solid-start-v2/with-solidbase/README.md
+++ b/solid-start-v2/with-solidbase/README.md
@@ -25,8 +25,8 @@ npm run dev -- --open
 
 ## Building
 
-Solid apps are built with _presets_, which optimise your project for deployment to different environments.
+Solid apps are built with Nitro _presets_, which optimise your project for deployment to different environments.
 
-By default, `npm run build` will generate a Node app that you can run with `npm start`. To use a different preset, add it to the `devDependencies` in `package.json` and specify in your `app.config.js`.
+By default, `npm run build` will generate a Node app under `.output` that you can run with `npm start`. To use a different preset, set it on the `nitro()` plugin in your `vite.config.ts`.
 
 ## This project was created with the [Solid CLI](https://solid-cli.netlify.app)

--- a/solid-start-v2/with-tailwindcss/README.md
+++ b/solid-start-v2/with-tailwindcss/README.md
@@ -25,6 +25,6 @@ npm run dev -- --open
 
 ## Building
 
-Solid apps are built with _presets_, which optimise your project for deployment to different environments.
+Solid apps are built with Nitro _presets_, which optimise your project for deployment to different environments.
 
-By default, `npm run build` will generate a Node app that you can run with `npm start`. To use a different preset, add it to the `devDependencies` in `package.json` and specify in your `app.config.js`.
+By default, `npm run build` will generate a Node app under `.output` that you can run with `npm start`. To use a different preset, set it on the `nitro()` plugin in your `vite.config.ts`.

--- a/solid-start-v2/with-tanstack-router/README.md
+++ b/solid-start-v2/with-tanstack-router/README.md
@@ -25,6 +25,6 @@ npm run dev -- --open
 
 ## Building
 
-Solid apps are built with _presets_, which optimise your project for deployment to different environments.
+Solid apps are built with Nitro _presets_, which optimise your project for deployment to different environments.
 
-By default, `npm run build` will generate a Node app that you can run with `npm start`. To use a different preset, add it to the `devDependencies` in `package.json` and specify in your `app.config.js`.
+By default, `npm run build` will generate a Node app under `.output` that you can run with `npm start`. To use a different preset, set it on the `nitro()` plugin in your `vite.config.ts`.

--- a/solid-start-v2/with-trpc/README.md
+++ b/solid-start-v2/with-trpc/README.md
@@ -25,6 +25,6 @@ npm run dev -- --open
 
 ## Building
 
-Solid apps are built with _presets_, which optimise your project for deployment to different environments.
+Solid apps are built with Nitro _presets_, which optimise your project for deployment to different environments.
 
-By default, `npm run build` will generate a Node app that you can run with `npm start`. To use a different preset, add it to the `devDependencies` in `package.json` and specify in your `app.config.js`.
+By default, `npm run build` will generate a Node app under `.output` that you can run with `npm start`. To use a different preset, set it on the `nitro()` plugin in your `vite.config.ts`.

--- a/solid-start-v2/with-unocss/README.md
+++ b/solid-start-v2/with-unocss/README.md
@@ -25,6 +25,6 @@ npm run dev -- --open
 
 ## Building
 
-Solid apps are built with _presets_, which optimise your project for deployment to different environments.
+Solid apps are built with Nitro _presets_, which optimise your project for deployment to different environments.
 
-By default, `npm run build` will generate a Node app that you can run with `npm start`. To use a different preset, add it to the `devDependencies` in `package.json` and specify in your `app.config.js`.
+By default, `npm run build` will generate a Node app under `.output` that you can run with `npm start`. To use a different preset, set it on the `nitro()` plugin in your `vite.config.ts`.

--- a/solid-start-v2/with-vitest/README.md
+++ b/solid-start-v2/with-vitest/README.md
@@ -25,9 +25,9 @@ npm run dev -- --open
 
 ## Building
 
-Solid apps are built with _presets_, which optimise your project for deployment to different environments.
+Solid apps are built with Nitro _presets_, which optimise your project for deployment to different environments.
 
-By default, `npm run build` will generate a Node app that you can run with `npm start`. To use a different preset, add it to the `devDependencies` in `package.json` and specify in your `app.config.js`.
+By default, `npm run build` will generate a Node app under `.output` that you can run with `npm start`. To use a different preset, set it on the `nitro()` plugin in your `vite.config.ts`.
 
 ## Testing
 


### PR DESCRIPTION
The `solid-start-v2` templates still carry the v1 wording in their **Building** section, which is inaccurate for SolidStart 2:

- It points at `app.config.js`, which v2 replaced with `vite.config.ts`.
- It says to add a preset to `devDependencies` in `package.json`. Nitro presets are built in, so nothing needs installing; the preset is set on the `nitro()` plugin.

### Change

```diff
-Solid apps are built with _presets_, which optimise your project for deployment to different environments.
+Solid apps are built with Nitro _presets_, which optimise your project for deployment to different environments.

-By default, `npm run build` will generate a Node app that you can run with `npm start`. To use a different preset, add it to the `devDependencies` in `package.json` and specify in your `app.config.js`.
+By default, `npm run build` will generate a Node app under `.output` that you can run with `npm start`. To use a different preset, set it on the `nitro()` plugin in your `vite.config.ts`.
```

`npm start` is left as is, since every affected template already defines `"start": "node .output/server/index.mjs"`.

`with-drizzle` also called these _adapters_; normalised to _presets_ to match the other templates and Nitro's own terminology.

### Scope

12 templates: `bare`, `basic`, `with-drizzle`, `with-mdx`, `with-prisma`, `with-solid-styled`, `with-solidbase`, `with-tailwindcss`, `with-tanstack-router`, `with-trpc`, `with-unocss`, `with-vitest`.

`with-auth`, `with-authjs`, and `with-strict-csp` have no Building section, so they are untouched.

I checked that all 12 depend on `nitro` ^3 and configure it via the `nitro()` plugin in `vite.config.ts`, so the new wording is accurate for each. Docs only, no code changes.