### PR TITLE
Remove trailing blank line from with-authjs READMEs

### DIFF
--- a/solid-start-v1/with-authjs/README.md
+++ b/solid-start-v1/with-authjs/README.md
@@ -17,4 +17,3 @@ This will start a production server on port `3000`.
 - `AUTH_SECRET`=b198e07a64406260b98f06e21c457b84
 - `AUTH_TRUST_HOST`=true
 - `AUTH_URL`=http://localhost:3000/api/auth
-

--- a/solid-start-v2/with-authjs/README.md
+++ b/solid-start-v2/with-authjs/README.md
@@ -17,4 +17,3 @@ This will start a production server on port `3000`.
 - `AUTH_SECRET`=b198e07a64406260b98f06e21c457b84
 - `AUTH_TRUST_HOST`=true
 - `AUTH_URL`=http://localhost:3000/api/auth
-


### PR DESCRIPTION
Both `with-authjs` READMEs have a duplicate trailing newline, so they fail `prettier --check` while every other file in the repo passes:

```
$ npx prettier --check "**/*.md"
[warn] solid-start-v1/with-authjs/README.md
[warn] solid-start-v2/with-authjs/README.md
```

Ran `prettier --write` on the two files. The only change is dropping the extra blank line at the end of each, one deletion per file. With this, `prettier --check "**/*.md"` is clean across the repo.

Formatting only, no content changes. Independent of #272, which touches a different set of files.