### PR TITLE
solid-v2: switch fullstack templates from zod to valibot

### DIFF
--- a/solid-v2/fullstack-tanstack/env.ts
+++ b/solid-v2/fullstack-tanstack/env.ts
@@ -1,7 +1,7 @@
-import { z } from 'zod';
+import * as v from 'valibot';
 
 // The typed env schema (probed by the plugin from the project root): plain
-// objects of Standard Schema validators — zod here, but valibot, arktype, or
+// objects of Standard Schema validators — valibot here, but zod, arktype, or
 // any compliant library works, even mixed per key.
 //
 // `server` vars come through `virtual:env/server` (server modules only —
@@ -14,9 +14,9 @@ export default {
   server: {
     // Comma-separated, newest first — see src/server/session.ts for the
     // rotation story. Generate one: `openssl rand -base64 32`.
-    SESSION_SECRET: z.string().min(32),
+    SESSION_SECRET: v.pipe(v.string(), v.minLength(32)),
   },
   client: {
-    VITE_APP_NAME: z.string().min(1).default('Solid App'),
+    VITE_APP_NAME: v.optional(v.pipe(v.string(), v.minLength(1)), 'Solid App'),
   },
 };

--- a/solid-v2/fullstack-tanstack/package.json
+++ b/solid-v2/fullstack-tanstack/package.json
@@ -28,7 +28,7 @@
     "@solidjs/web": "^2.0.0-rc.0",
     "@tanstack/solid-router": "^2.0.0-rc.0",
     "solid-js": "^2.0.0-rc.0",
-    "zod": "^4.1.13",
+    "valibot": "^1.4.2",
     "@tanstack/solid-query": "^6.0.0-rc.0"
   }
 }

--- a/solid-v2/fullstack-tanstack/pnpm-lock.yaml
+++ b/solid-v2/fullstack-tanstack/pnpm-lock.yaml
@@ -23,9 +23,9 @@ importers:
       solid-js:
         specifier: ^2.0.0-rc.0
         version: 2.0.0-rc.0
-      zod:
-        specifier: ^4.1.13
-        version: 4.4.3
+      valibot:
+        specifier: ^1.4.2
+        version: 1.4.2(typescript@5.9.3)
     devDependencies:
       '@solidjs/testing-library':
         specifier: 1.0.0-beta.2
@@ -1409,6 +1409,14 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   validate-html-nesting@1.2.4:
     resolution: {integrity: sha512-doQi7e8EJ2OWneSG1aZpJluS6A49aZM0+EICXWKm1i6WvqTLmq0tpUcImc4KTWG50mORO0C4YDBtOCSYvElftw==}
@@ -2849,6 +2857,10 @@ snapshots:
       browserslist: 4.28.8
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  valibot@1.4.2(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
 
   validate-html-nesting@1.2.4: {}
 

--- a/solid-v2/fullstack/README.md
+++ b/solid-v2/fullstack/README.md
@@ -38,7 +38,7 @@ The demo wires it as auth: `login`/`logout` actions write the cookie, `getCurren
 
 ## Typed environment variables
 
-`env.ts` at the project root declares every variable as a [Standard Schema](https://standardschema.dev) validator (zod here; valibot or arktype work identically — nothing is imported from the plugin). The plugin probes it automatically and serves two fully typed virtual modules; generated types land in `solid-env.d.ts`.
+`env.ts` at the project root declares every variable as a [Standard Schema](https://standardschema.dev) validator (valibot here; zod or arktype work identically — nothing is imported from the plugin). The plugin probes it automatically and serves two fully typed virtual modules; generated types land in `solid-env.d.ts`.
 
 - **`virtual:env/server`** — every var, **read from `process.env` when the server boots** and validated then: secrets rotate without a rebuild, platform-injected vars work, and no secret value exists in any build artifact. A misconfigured server fails at boot with a per-key report (delete `SESSION_SECRET` from `.env` and run `npm start` to see it). Importing this module from client code fails the build, naming the importer.
 - **`virtual:env/client`** — the `VITE_`-prefixed vars, validated and **baked into the bundle** at build time (defaults applied, zero schema-library bytes shipped). The prefix is the line: client values are public, server values never leave the server.
@@ -118,7 +118,7 @@ The default `{ fetch(request) }` export follows the Fetchable convention used by
 
 1. **Serve `dist/client` statically**, and route everything else — pages, `/_server`, API routes — to `handleRequest`.
 2. **Provide the server env vars** (`SESSION_SECRET` here) in the process environment: the server bundle reads and validates them **at boot**, not at build time, so they come from the platform's env/secret settings — never from a build artifact. Client `VITE_` vars are the opposite: baked in at `vite build`, so set those on the build machine/CI.
-3. **Resolve the bundle's dependencies**: `dist/server` imports its npm deps (`solid-js`, `@solidjs/web`, `zod`, ...) as bare specifiers rather than inlining them, so whatever runs or re-bundles it needs `node_modules` present — true in every recipe below. The bundle itself is pure web-standard code (no `node:` imports, no top-level `await`).
+3. **Resolve the bundle's dependencies**: `dist/server` imports its npm deps (`solid-js`, `@solidjs/web`, `valibot`, ...) as bare specifiers rather than inlining them, so whatever runs or re-bundles it needs `node_modules` present — true in every recipe below. The bundle itself is pure web-standard code (no `node:` imports, no top-level `await`).
 
 ### Node
 

--- a/solid-v2/fullstack/env.ts
+++ b/solid-v2/fullstack/env.ts
@@ -1,7 +1,7 @@
-import { z } from 'zod';
+import * as v from 'valibot';
 
 // The typed env schema (probed by the plugin from the project root): plain
-// objects of Standard Schema validators — zod here, but valibot, arktype, or
+// objects of Standard Schema validators — valibot here, but zod, arktype, or
 // any compliant library works, even mixed per key.
 //
 // `server` vars come through `virtual:env/server` (server modules only —
@@ -14,9 +14,9 @@ export default {
   server: {
     // Comma-separated, newest first — see src/server/session.ts for the
     // rotation story. Generate one: `openssl rand -base64 32`.
-    SESSION_SECRET: z.string().min(32),
+    SESSION_SECRET: v.pipe(v.string(), v.minLength(32)),
   },
   client: {
-    VITE_APP_NAME: z.string().min(1).default('Solid App'),
+    VITE_APP_NAME: v.optional(v.pipe(v.string(), v.minLength(1)), 'Solid App'),
   },
 };

--- a/solid-v2/fullstack/package.json
+++ b/solid-v2/fullstack/package.json
@@ -28,6 +28,6 @@
     "@solidjs/router": "^2.0.0-next.16",
     "@solidjs/web": "^2.0.0-rc.0",
     "solid-js": "^2.0.0-rc.0",
-    "zod": "^4.1.13"
+    "valibot": "^1.4.2"
   }
 }

--- a/solid-v2/fullstack/pnpm-lock.yaml
+++ b/solid-v2/fullstack/pnpm-lock.yaml
@@ -23,9 +23,9 @@ importers:
       solid-js:
         specifier: ^2.0.0-rc.0
         version: 2.0.0-rc.0
-      zod:
-        specifier: ^4.1.13
-        version: 4.4.3
+      valibot:
+        specifier: ^1.4.2
+        version: 1.4.2(typescript@5.9.3)
     devDependencies:
       '@solidjs/testing-library':
         specifier: 1.0.0-beta.2
@@ -1199,6 +1199,14 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   validate-html-nesting@1.2.4:
     resolution: {integrity: sha512-doQi7e8EJ2OWneSG1aZpJluS6A49aZM0+EICXWKm1i6WvqTLmq0tpUcImc4KTWG50mORO0C4YDBtOCSYvElftw==}
 
@@ -1341,9 +1349,6 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-
-  zod@4.4.3:
-    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -2412,6 +2417,10 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
+  valibot@1.4.2(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
+
   validate-html-nesting@1.2.4: {}
 
   vite@8.2.1(@types/node@26.2.0):
@@ -2486,5 +2495,3 @@ snapshots:
   xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
-
-  zod@4.4.3: {}


### PR DESCRIPTION
## Summary

Switches the `solid-v2/fullstack` and `solid-v2/fullstack-tanstack` templates from zod to valibot:

- `env.ts` in both templates rewritten with valibot (`v.pipe(v.string(), v.minLength(32))` for `SESSION_SECRET`, `v.optional(v.pipe(v.string(), v.minLength(1)), 'Solid App')` for `VITE_APP_NAME`); the comment now lists zod/arktype as the alternatives
- `package.json` deps: `zod` → `valibot@^1.4.2`, lockfiles regenerated
- `fullstack/README.md` updated to name valibot in the Standard Schema paragraph and the server-bundle deps list

The env plugin consumes the Standard Schema interface, so only the example library changes — no plugin or config changes.

## Verification

- Both templates build cleanly (client env values are validated at build time, exercising the valibot schemas)
- Both vitest suites pass (10/10 each)
- `solid-env.d.ts` regenerates with correct inferred types from valibot's Standard Schema output

Companion docs PR: solidjs/solid-docs#1634

🤖 Generated with [Claude Code](https://claude.com/claude-code)