### PR TITLE
fix(with-unocss): repair broken styles in dev and prod for solid-start-v2

### DIFF
--- a/solid-start-v2/with-unocss/vite.config.ts
+++ b/solid-start-v2/with-unocss/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { defineConfig, searchForWorkspaceRoot } from "vite";
 import { nitro } from "nitro/vite";
 import { solidStart } from "@solidjs/start/config";
 import UnoCSS from "unocss/vite";
@@ -6,11 +6,25 @@ import presetWind4 from "@unocss/preset-wind4";
 
 export default defineConfig({
   plugins: [
-    solidStart(),
+    // UnoCSS must run before solidStart so classes are extracted from source
+    // JSX rather than Solid's compiled templates, which omit attribute quotes
     UnoCSS({
       mode: "per-module",
       presets: [presetWind4()]
     }),
+    solidStart(),
     nitro()
-  ]
+  ],
+  server: {
+    fs: {
+      // solid-start's dev SSR manifest loads collected CSS with `?inline`,
+      // and Vite fs-checks those requests, denying UnoCSS's virtual ids
+      allow: [
+        searchForWorkspaceRoot(process.cwd()),
+        "/__uno.css",
+        "/__uno.css?inline",
+        "/@unocss"
+      ]
+    }
+  }
 });


### PR DESCRIPTION
Fixes the UnoCSS half of #255 (the reported prod 404 itself was already fixed by #261 — `pnpm start` now runs the Nitro server on port 3000).

## Problems

**Dev: every page 500s.** solid-start's dev SSR manifest imports each collected CSS id with `?inline`, and Vite 8 runs a `server.fs` access check on `?inline` transforms. UnoCSS's virtual ids (`/__uno.css`, `/@unocss/<hash>.css`) look like filesystem paths outside the allow list, so Vite throws `Denied ID /__uno.css?inline` and the whole render fails.

**Prod: utilities from single-class attributes are missing.** With UnoCSS running after `solidStart()`, extraction happens on Solid's compiled client templates, which omit attribute quotes when there's a single class (`<nav class=bg-sky-800>`). Uno's extractor can't tokenize that, so e.g. the Nav's `bg-sky-800` never made it into the built CSS.

## Fixes

- Move `UnoCSS()` before `solidStart()` so classes are extracted from source JSX.
- Add UnoCSS's virtual ids to `server.fs.allow` (re-adding `searchForWorkspaceRoot`, since setting `fs.allow` replaces Vite's default). This is a workaround — the underlying issue belongs in solid-start, which should tolerate virtual CSS ids in its `?inline` style crawl; once fixed there this block can be removed.
- Delete the empty 0-byte `uno.config.ts`.

## Verified

- `vite dev`: pages render 200 with styles (previously 500 on every request)
- `pnpm build && pnpm start`: served CSS contains all utilities, including `bg-sky-800`, with no leftover `#--unocss--` placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)