### PR TITLE
solid-v2: enable agent diagnostics and add AGENTS.md to all templates

### DIFF
--- a/solid-v2/bare/AGENTS.md
+++ b/solid-v2/bare/AGENTS.md
@@ -1,0 +1,23 @@
+# Agent Guide
+
+This is a SolidJS 2.x project. Solid is not React: components run once (there is no re-render), reactivity is fine-grained through signals, and effects/memos have Solid-specific semantics. Do not port React patterns.
+
+## Versioned skills (in node_modules — read on demand)
+
+The installed packages ship agent skills that match their exact installed versions:
+
+- `node_modules/solid-js/skills/reactivity-diagnostics/SKILL.md` — repair guide mapping every dev-mode diagnostic code (e.g. `REACTIVE_WRITE_IN_OWNED_SCOPE`, `STRICT_READ_UNTRACKED`) to its prescribed fix. Read it whenever a Solid diagnostic code appears in test output or the browser console.
+- `node_modules/@solidjs/diagnostics/skills/agent-loops/SKILL.md` — how to capture reactive evidence (which scopes re-ran and why, wasted recomputes, cost tables) and assert budgets, in tests and against live pages.
+
+## Reactive diagnostics — capture evidence instead of guessing
+
+Use these whenever you are debugging reactivity (something doesn't update, updates too often, or is slow) or verifying a change didn't regress update granularity:
+
+- **In tests:** `captureArtifact()` from `@solidjs/diagnostics` wraps a scenario and returns a serializable artifact of diagnostics + rerun attribution; matchers from `@solidjs/diagnostics/vitest` (`toHaveNoDiagnostics`, `toStayWithinRerunBudget`, `toHaveNoWaste`, …) assert on it. No browser needed.
+- **Against the running dev server** (`diagnostics: true` in vite.config.ts; dev-only, no-op in builds). Requires an open page connected to the dev server (e.g. via a browser tool):
+  - `GET /__solid/diagnostics` — status and connected client count
+  - `POST /__solid/diagnostics` with JSON `{"method":"begin"}` then `{"method":"end"}` — capture a session into an artifact
+  - `{"method":"whyDidRun","params":{"name":"<scope name>"}}` — recorded re-runs of one named scope in the open session
+  - `{"method":"costs"}` — running cost tables for the open session
+
+Name your signals/memos/effects (the `{ name: "..." }` option) — attribution reports scopes by name.

--- a/solid-v2/bare/package.json
+++ b/solid-v2/bare/package.json
@@ -12,14 +12,15 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@solidjs/vite-plugin": "^3.0.0-next.33",
+    "@solidjs/diagnostics": "^2.0.0-rc.3",
+    "@solidjs/vite-plugin": "^3.0.0-next.34",
     "eslint-plugin-solid": "~0.16.0",
     "oxlint": "~1.79.0",
     "typescript": "^5.9.2",
     "vite": "^8.1.5"
   },
   "dependencies": {
-    "@solidjs/web": "^2.0.0-rc.2",
-    "solid-js": "^2.0.0-rc.2"
+    "@solidjs/web": "^2.0.0-rc.3",
+    "solid-js": "^2.0.0-rc.3"
   }
 }

--- a/solid-v2/bare/pnpm-lock.yaml
+++ b/solid-v2/bare/pnpm-lock.yaml
@@ -9,15 +9,18 @@ importers:
   .:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-rc.2
-        version: 2.0.0-rc.2(solid-js@2.0.0-rc.2)
+        specifier: ^2.0.0-rc.3
+        version: 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       solid-js:
-        specifier: ^2.0.0-rc.2
-        version: 2.0.0-rc.2
+        specifier: ^2.0.0-rc.3
+        version: 2.0.0-rc.3
     devDependencies:
+      '@solidjs/diagnostics':
+        specifier: ^2.0.0-rc.3
+        version: 2.0.0-rc.3
       '@solidjs/vite-plugin':
-        specifier: ^3.0.0-next.33
-        version: 3.0.0-next.33(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)(vite@8.2.1)
+        specifier: ^3.0.0-next.34
+        version: 3.0.0-next.34(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.2.1)
       eslint-plugin-solid:
         specifier: ~0.16.0
         version: 0.16.0(eslint@10.8.1)(typescript@5.9.3)
@@ -118,53 +121,14 @@ packages:
     resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.42':
-    resolution: {integrity: sha512-ol24x9RW8loPyOTzC/mQzh/zAsrsPxyTG4WRxxRlwzNK2uBWIBftWN5IwmSV51zDQa7JcT6sE6kkXFCLUvsYIQ==}
-    peerDependencies:
-      '@babel/core': ^7.20.12
+  '@emnapi/core@1.11.3':
+    resolution: {integrity: sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==}
 
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
-    resolution: {integrity: sha512-7l575p7EQu16lssfbtgspSBWBSK5+car5NP4VYD/iJiK+Qd2VcMQMwaOjgA1xCs/P0S0l9EFY9BHGIJcHQTL+w==}
-    cpu: [arm64]
-    os: [darwin]
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
-    resolution: {integrity: sha512-NRbfI3HhBPsSrSQvSUfQXvPXfEKjUQKnbBVCDvcu7ISBPMQd+0yH9M+Qmlf7kVq4Ci9qa1HL5EA2jD22d2v73A==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
-    resolution: {integrity: sha512-/Gfa8j/YHBKK1i8b2VQw3ewBlA6qlEZSAn+b7g3z1g18WydPUI/TZWISKpgNxAtyl9m9MvwgbWA1HcHVkf4zyg==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
-    resolution: {integrity: sha512-gV4J4Sr1+6Awnkl5npREqPvxcDfgw4PGguTdFnsHVN9cxAFet3ujcCbWsAJ+QMBUQ8OT/LG6d4oJLlAkQ0D1fA==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
-    resolution: {integrity: sha512-YrzoB/YZtrmnGXhz3sxs7VeuAXT0JRc6NguNX8iDNt5p5fQ0QX+HR75GYMsxY9FceSVTHObrm3fA/8KGYo5z6Q==}
-    engines: {node: '>=14.0.0'}
-
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
-    resolution: {integrity: sha512-BNQEgny4zyjceZqCaRJDCrQ2oy6z7oXruAE/du2uJB7qLz/z24ISJVUKeKHPb5mRzHuSiTlDcK7pDzE7jPPXjg==}
-    cpu: [x64]
-    os: [win32]
-
-  '@dom-expressions/compiler@0.50.0-next.44':
-    resolution: {integrity: sha512-CBj0k+LcpCk8+nJGY7uvqxLC5NLxXTx9l0fuMZBBkBAOgVf5/IlMyMSpaYE5H5AkFiajR05NYvNR07R6e0KZ3w==}
-
-  '@emnapi/core@1.11.2':
-    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
-
-  '@emnapi/runtime@1.11.2':
-    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
-
-  '@emnapi/wasi-threads@1.2.2':
-    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+  '@emnapi/wasi-threads@1.2.3':
+    resolution: {integrity: sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==}
 
   '@eslint-community/eslint-utils@4.10.1':
     resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
@@ -457,11 +421,58 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
-  '@solidjs/signals@2.0.0-rc.2':
-    resolution: {integrity: sha512-nJyXdBZJaYGqtDuQt8csE9LY9oNZV2fZfPRmJHQT9QjQEuHKQ1OaZScZ8YFaeATrnavzys4Ws95LnUdv8pCidQ==}
+  '@solidjs/babel-plugin@2.0.0-rc.3':
+    resolution: {integrity: sha512-VLqCvvMukrACeMuF3uPTyx9l+qCQ9H1G25vOl7FXAdu9rMrLEKZ2IEoiUMczn0mhXAVeplJVEvr7+gSy5m4omA==}
+    peerDependencies:
+      '@babel/core': ^7.20.12
 
-  '@solidjs/vite-plugin@3.0.0-next.33':
-    resolution: {integrity: sha512-8c6twAU/ko9TUEr3koPnWQ1CzET+muZPJFaxBSLYv0M+WRgtmbjlHl9GxTSfm5dd23JDwGhBcv3gdxr2slV/wg==}
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.3':
+    resolution: {integrity: sha512-P9Ngf6KUwM+KGAAUZ40776+1utbk/n3+F+WhyyYm+rUpjO0um9EqBJLvafqEp6kGgSHQ2j5UhioqcuqhesMLbQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.3':
+    resolution: {integrity: sha512-PozalaeiMJxPF7H5ePpqOGM8F9H07sFsSGxyHHZiUn8c4HIBlsacNpc06gUcoJ1xzm7AvayNCV9BJOw2hQYaYg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3':
+    resolution: {integrity: sha512-riY4uwHCqq5vfrlYY7AK8xy/r/Wd98NCnbGqFsDb7bL7TNw398VuA5+hoK4cnsQJe4dqvI2zXFEdmP5xSNAFSQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3':
+    resolution: {integrity: sha512-y2GlcmfIqtWBrxOnvgLsGZvdH2tVK/9JzcFTUzWo5kjoiEy+VCV3NSNcBZrMbLJ7ozIDTiuWePZd/G5LphYdmA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3':
+    resolution: {integrity: sha512-mx7LnrAwKaXd9ZiaAwZeBlMjdWNdmR73F+3I1iOxSpH9Lh2Kyx9IIVff0a1AnwUy17tdDxXMbWxoI/ctYfZsdw==}
+    engines: {node: '>=14.0.0'}
+
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3':
+    resolution: {integrity: sha512-7MQDvdSI42/+lSac6L6WVgCYkUezzliLRoCjo7ultpN2hHy3XgohxvrWfE005OQEMg2pamzzFmfeIl8FUi2JRA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@solidjs/compiler@2.0.0-rc.3':
+    resolution: {integrity: sha512-gu2AnJwkrJfk3SBKGRxEUGuP/SZpwUGzHQS5zt56eNG4GFlEMyurahVRSLMWWBhtC1On7wH5SmLxybH2yDCqAg==}
+
+  '@solidjs/diagnostics@2.0.0-rc.3':
+    resolution: {integrity: sha512-fPb20MXqN7LpT02+kxfMBhY3reCKeh7vB++g9Su1EJZ6Ie0PeydyU/CnkUNa9gwLCMKoZG1x0pfAMb9yLGowtw==}
+    peerDependencies:
+      vitest: '>=2.0.0'
+    peerDependenciesMeta:
+      vitest:
+        optional: true
+
+  '@solidjs/signals@2.0.0-rc.3':
+    resolution: {integrity: sha512-/yPhTf3xS1FRR4MX8kTYCd4MjsFxzwkO+KyOTfbu35lTEiaJ4Fxy+JL91XonDzt31GV1mYaZ9CGD2TQIzvXuNA==}
+
+  '@solidjs/vite-plugin@3.0.0-next.34':
+    resolution: {integrity: sha512-uDxBcBjbcS6k509TXTsNw4PjubT59eInzLAny43N5Ieoa4jROCaWV+EwxedPqtCF7nsHoKGgwC+ysu6w105G0A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@solidjs/start-devtools': ^1.0.0-next.2
@@ -475,10 +486,10 @@ packages:
       '@testing-library/jest-dom':
         optional: true
 
-  '@solidjs/web@2.0.0-rc.2':
-    resolution: {integrity: sha512-JazuW9NCI+kcpZXRq9J/DAGPmMd0pEWr3kuXFmPZV9tOviiTOHDXOf56pjbUFVDZd+120AKoe/ULmYdSDpJmsA==}
+  '@solidjs/web@2.0.0-rc.3':
+    resolution: {integrity: sha512-5ckKgOjem1pN5ADycOk6TjHmTtjbbN2fukqxo6RW3Oe3H7z0gaXWAdt8dLISto5/O4Nn8VxprFXFWpfy31+DUg==}
     peerDependencies:
-      solid-js: ^2.0.0-rc.2
+      solid-js: ^2.0.0-rc.3
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -553,15 +564,6 @@ packages:
 
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
-
-  babel-preset-solid@2.0.0-rc.0:
-    resolution: {integrity: sha512-Ap2/QQY3pICj+Q0VM/RnIOpZo7e6icZnUA0oBJuhqzoCrljqMNo3eFb2OeEa4pUQeFREJOlex4Bt1ggwrcgC8w==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-rc.0
-    peerDependenciesMeta:
-      solid-js:
-        optional: true
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -983,8 +985,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  solid-js@2.0.0-rc.2:
-    resolution: {integrity: sha512-1C++20cho5f+omXbX6MIl+VrBZ+by6QkWpCtpbVmmUR80EGgH4irqV0UdP88GAYHx1U+FzpCcHxIGoA9raCyQA==}
+  solid-js@2.0.0-rc.3:
+    resolution: {integrity: sha512-pmW6bRoTvfp/rN4jN7JmLvSaoIpFt7wm0Hi3j508S/smuJqUbRg3dQEjOPTkAwHW+McYnXrMG7cJ4AMNpLevtQ==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -1212,59 +1214,18 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.42(@babel/core@7.29.7)':
+  '@emnapi/core@1.11.3':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
-      '@babel/types': 7.29.8
-      html-entities: 2.3.3
-      parse5: 7.3.0
-      validate-html-nesting: 1.2.4
-
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
-    dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
-      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
-    optional: true
-
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler@0.50.0-next.44':
-    optionalDependencies:
-      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.44
-      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.44
-      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.44
-      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.44
-      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.44
-      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.44
-
-  '@emnapi/core@1.11.2':
-    dependencies:
-      '@emnapi/wasi-threads': 1.2.2
+      '@emnapi/wasi-threads': 1.2.3
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.11.2':
+  '@emnapi/runtime@1.11.3':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/wasi-threads@1.2.2':
+  '@emnapi/wasi-threads@1.2.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -1334,10 +1295,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -1444,28 +1405,73 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@solidjs/signals@2.0.0-rc.2': {}
+  '@solidjs/babel-plugin@2.0.0-rc.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/types': 7.29.8
+      html-entities: 2.3.3
+      parse5: 7.3.0
+      validate-html-nesting: 1.2.4
 
-  '@solidjs/vite-plugin@3.0.0-next.33(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)(vite@8.2.1)':
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3':
+    dependencies:
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+    optional: true
+
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler@2.0.0-rc.3':
+    optionalDependencies:
+      '@solidjs/compiler-darwin-arm64': 2.0.0-rc.3
+      '@solidjs/compiler-darwin-x64': 2.0.0-rc.3
+      '@solidjs/compiler-linux-arm64-gnu': 2.0.0-rc.3
+      '@solidjs/compiler-linux-x64-gnu': 2.0.0-rc.3
+      '@solidjs/compiler-wasm32-wasi': 2.0.0-rc.3
+      '@solidjs/compiler-win32-x64-msvc': 2.0.0-rc.3
+
+  '@solidjs/diagnostics@2.0.0-rc.3':
+    dependencies:
+      '@solidjs/signals': 2.0.0-rc.3
+
+  '@solidjs/signals@2.0.0-rc.3': {}
+
+  '@solidjs/vite-plugin@3.0.0-next.34(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.2.1)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/core': 7.29.7
-      '@dom-expressions/compiler': 0.50.0-next.44
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
+      '@solidjs/babel-plugin': 2.0.0-rc.3(@babel/core@7.29.7)
+      '@solidjs/compiler': 2.0.0-rc.3
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-rc.0(@babel/core@7.29.7)(solid-js@2.0.0-rc.2)
       merge-anything: 5.1.7
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
       vite: 8.2.1
       vitefu: 1.1.3(vite@8.2.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2)':
+  '@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3)':
     dependencies:
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -1562,13 +1568,6 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
-
-  babel-preset-solid@2.0.0-rc.0(@babel/core@7.29.7)(solid-js@2.0.0-rc.2):
-    dependencies:
-      '@babel/core': 7.29.7
-      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.42(@babel/core@7.29.7)
-    optionalDependencies:
-      solid-js: 2.0.0-rc.2
 
   balanced-match@4.0.4: {}
 
@@ -1945,9 +1944,9 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  solid-js@2.0.0-rc.2:
+  solid-js@2.0.0-rc.3:
     dependencies:
-      '@solidjs/signals': 2.0.0-rc.2
+      '@solidjs/signals': 2.0.0-rc.3
       csstype: 3.2.3
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)

--- a/solid-v2/bare/vite.config.ts
+++ b/solid-v2/bare/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   // (or a built-in shell). `vite build` prerenders the shell into
   // dist/client/index.html and emits a purely static dist/client.
   plugins: [
-    solid({ start: true }), // add `ssr: true` for streaming SSR
+    solid({ start: true, diagnostics: true }), // add `ssr: true` for streaming SSR
   ],
   server: {
     port: 3000,

--- a/solid-v2/basic/AGENTS.md
+++ b/solid-v2/basic/AGENTS.md
@@ -1,0 +1,23 @@
+# Agent Guide
+
+This is a SolidJS 2.x project. Solid is not React: components run once (there is no re-render), reactivity is fine-grained through signals, and effects/memos have Solid-specific semantics. Do not port React patterns.
+
+## Versioned skills (in node_modules — read on demand)
+
+The installed packages ship agent skills that match their exact installed versions:
+
+- `node_modules/solid-js/skills/reactivity-diagnostics/SKILL.md` — repair guide mapping every dev-mode diagnostic code (e.g. `REACTIVE_WRITE_IN_OWNED_SCOPE`, `STRICT_READ_UNTRACKED`) to its prescribed fix. Read it whenever a Solid diagnostic code appears in test output or the browser console.
+- `node_modules/@solidjs/diagnostics/skills/agent-loops/SKILL.md` — how to capture reactive evidence (which scopes re-ran and why, wasted recomputes, cost tables) and assert budgets, in tests and against live pages.
+
+## Reactive diagnostics — capture evidence instead of guessing
+
+Use these whenever you are debugging reactivity (something doesn't update, updates too often, or is slow) or verifying a change didn't regress update granularity:
+
+- **In tests:** `captureArtifact()` from `@solidjs/diagnostics` wraps a scenario and returns a serializable artifact of diagnostics + rerun attribution; matchers from `@solidjs/diagnostics/vitest` (`toHaveNoDiagnostics`, `toStayWithinRerunBudget`, `toHaveNoWaste`, …) assert on it. No browser needed.
+- **Against the running dev server** (`diagnostics: true` in vite.config.ts; dev-only, no-op in builds). Requires an open page connected to the dev server (e.g. via a browser tool):
+  - `GET /__solid/diagnostics` — status and connected client count
+  - `POST /__solid/diagnostics` with JSON `{"method":"begin"}` then `{"method":"end"}` — capture a session into an artifact
+  - `{"method":"whyDidRun","params":{"name":"<scope name>"}}` — recorded re-runs of one named scope in the open session
+  - `{"method":"costs"}` — running cost tables for the open session
+
+Name your signals/memos/effects (the `{ name: "..." }` option) — attribution reports scopes by name.

--- a/solid-v2/basic/package.json
+++ b/solid-v2/basic/package.json
@@ -13,8 +13,9 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@solidjs/testing-library": "1.0.0-beta.2",
-    "@solidjs/vite-plugin": "^3.0.0-next.33",
+    "@solidjs/diagnostics": "^2.0.0-rc.3",
+    "@solidjs/testing-library": "^1.0.0-beta.2",
+    "@solidjs/vite-plugin": "^3.0.0-next.34",
     "@testing-library/jest-dom": "^6.6.3",
     "eslint-plugin-solid": "~0.16.0",
     "filesystem-routing": "0.2.1",
@@ -26,8 +27,8 @@
   },
   "dependencies": {
     "@solidjs/meta": "^1.0.0-next.2",
-    "@solidjs/router": "^2.0.0-next.16",
-    "@solidjs/web": "^2.0.0-rc.2",
-    "solid-js": "^2.0.0-rc.2"
+    "@solidjs/router": "^2.0.0-next.17",
+    "@solidjs/web": "^2.0.0-rc.3",
+    "solid-js": "^2.0.0-rc.3"
   }
 }

--- a/solid-v2/basic/pnpm-lock.yaml
+++ b/solid-v2/basic/pnpm-lock.yaml
@@ -10,23 +10,26 @@ importers:
     dependencies:
       '@solidjs/meta':
         specifier: ^1.0.0-next.2
-        version: 1.0.0-next.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)
+        version: 1.0.0-next.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/router':
-        specifier: ^2.0.0-next.16
-        version: 2.0.0-next.16(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)
+        specifier: ^2.0.0-next.17
+        version: 2.0.0-next.17(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/web':
-        specifier: ^2.0.0-rc.2
-        version: 2.0.0-rc.2(solid-js@2.0.0-rc.2)
+        specifier: ^2.0.0-rc.3
+        version: 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       solid-js:
-        specifier: ^2.0.0-rc.2
-        version: 2.0.0-rc.2
+        specifier: ^2.0.0-rc.3
+        version: 2.0.0-rc.3
     devDependencies:
+      '@solidjs/diagnostics':
+        specifier: ^2.0.0-rc.3
+        version: 2.0.0-rc.3(vitest@4.1.10(jsdom@25.0.1)(vite@8.2.1))
       '@solidjs/testing-library':
-        specifier: 1.0.0-beta.2
-        version: 1.0.0-beta.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)
+        specifier: ^1.0.0-beta.2
+        version: 1.0.0-beta.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/vite-plugin':
-        specifier: ^3.0.0-next.33
-        version: 3.0.0-next.33(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.2)(vite@8.2.1)
+        specifier: ^3.0.0-next.34
+        version: 3.0.0-next.34(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.3)(vite@8.2.1)
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.10.0(@testing-library/dom@10.4.1)
@@ -177,59 +180,23 @@ packages:
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.42':
-    resolution: {integrity: sha512-ol24x9RW8loPyOTzC/mQzh/zAsrsPxyTG4WRxxRlwzNK2uBWIBftWN5IwmSV51zDQa7JcT6sE6kkXFCLUvsYIQ==}
-    peerDependencies:
-      '@babel/core': ^7.20.12
-
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
-    resolution: {integrity: sha512-7l575p7EQu16lssfbtgspSBWBSK5+car5NP4VYD/iJiK+Qd2VcMQMwaOjgA1xCs/P0S0l9EFY9BHGIJcHQTL+w==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
-    resolution: {integrity: sha512-NRbfI3HhBPsSrSQvSUfQXvPXfEKjUQKnbBVCDvcu7ISBPMQd+0yH9M+Qmlf7kVq4Ci9qa1HL5EA2jD22d2v73A==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
-    resolution: {integrity: sha512-/Gfa8j/YHBKK1i8b2VQw3ewBlA6qlEZSAn+b7g3z1g18WydPUI/TZWISKpgNxAtyl9m9MvwgbWA1HcHVkf4zyg==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
-    resolution: {integrity: sha512-gV4J4Sr1+6Awnkl5npREqPvxcDfgw4PGguTdFnsHVN9cxAFet3ujcCbWsAJ+QMBUQ8OT/LG6d4oJLlAkQ0D1fA==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
-    resolution: {integrity: sha512-YrzoB/YZtrmnGXhz3sxs7VeuAXT0JRc6NguNX8iDNt5p5fQ0QX+HR75GYMsxY9FceSVTHObrm3fA/8KGYo5z6Q==}
-    engines: {node: '>=14.0.0'}
-
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
-    resolution: {integrity: sha512-BNQEgny4zyjceZqCaRJDCrQ2oy6z7oXruAE/du2uJB7qLz/z24ISJVUKeKHPb5mRzHuSiTlDcK7pDzE7jPPXjg==}
-    cpu: [x64]
-    os: [win32]
-
-  '@dom-expressions/compiler@0.50.0-next.44':
-    resolution: {integrity: sha512-CBj0k+LcpCk8+nJGY7uvqxLC5NLxXTx9l0fuMZBBkBAOgVf5/IlMyMSpaYE5H5AkFiajR05NYvNR07R6e0KZ3w==}
-
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
-  '@emnapi/core@1.11.2':
-    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+  '@emnapi/core@1.11.3':
+    resolution: {integrity: sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==}
 
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
-  '@emnapi/runtime@1.11.2':
-    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@emnapi/wasi-threads@1.2.3':
+    resolution: {integrity: sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==}
 
   '@eslint-community/eslint-utils@4.10.1':
     resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
@@ -664,20 +631,67 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@solidjs/babel-plugin@2.0.0-rc.3':
+    resolution: {integrity: sha512-VLqCvvMukrACeMuF3uPTyx9l+qCQ9H1G25vOl7FXAdu9rMrLEKZ2IEoiUMczn0mhXAVeplJVEvr7+gSy5m4omA==}
+    peerDependencies:
+      '@babel/core': ^7.20.12
+
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.3':
+    resolution: {integrity: sha512-P9Ngf6KUwM+KGAAUZ40776+1utbk/n3+F+WhyyYm+rUpjO0um9EqBJLvafqEp6kGgSHQ2j5UhioqcuqhesMLbQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.3':
+    resolution: {integrity: sha512-PozalaeiMJxPF7H5ePpqOGM8F9H07sFsSGxyHHZiUn8c4HIBlsacNpc06gUcoJ1xzm7AvayNCV9BJOw2hQYaYg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3':
+    resolution: {integrity: sha512-riY4uwHCqq5vfrlYY7AK8xy/r/Wd98NCnbGqFsDb7bL7TNw398VuA5+hoK4cnsQJe4dqvI2zXFEdmP5xSNAFSQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3':
+    resolution: {integrity: sha512-y2GlcmfIqtWBrxOnvgLsGZvdH2tVK/9JzcFTUzWo5kjoiEy+VCV3NSNcBZrMbLJ7ozIDTiuWePZd/G5LphYdmA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3':
+    resolution: {integrity: sha512-mx7LnrAwKaXd9ZiaAwZeBlMjdWNdmR73F+3I1iOxSpH9Lh2Kyx9IIVff0a1AnwUy17tdDxXMbWxoI/ctYfZsdw==}
+    engines: {node: '>=14.0.0'}
+
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3':
+    resolution: {integrity: sha512-7MQDvdSI42/+lSac6L6WVgCYkUezzliLRoCjo7ultpN2hHy3XgohxvrWfE005OQEMg2pamzzFmfeIl8FUi2JRA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@solidjs/compiler@2.0.0-rc.3':
+    resolution: {integrity: sha512-gu2AnJwkrJfk3SBKGRxEUGuP/SZpwUGzHQS5zt56eNG4GFlEMyurahVRSLMWWBhtC1On7wH5SmLxybH2yDCqAg==}
+
+  '@solidjs/diagnostics@2.0.0-rc.3':
+    resolution: {integrity: sha512-fPb20MXqN7LpT02+kxfMBhY3reCKeh7vB++g9Su1EJZ6Ie0PeydyU/CnkUNa9gwLCMKoZG1x0pfAMb9yLGowtw==}
+    peerDependencies:
+      vitest: '>=2.0.0'
+    peerDependenciesMeta:
+      vitest:
+        optional: true
+
   '@solidjs/meta@1.0.0-next.2':
     resolution: {integrity: sha512-4aqPczFqDdep4JTAUXfh4nyfq7InbTgimd7NuN6ZWWE29UPv0uR5dyr53yFcf2YgVXjFdX+JGhXtsE0njGL+fA==}
     peerDependencies:
       '@solidjs/web': ^2.0.0-rc.0
       solid-js: ^2.0.0-rc.0
 
-  '@solidjs/router@2.0.0-next.16':
-    resolution: {integrity: sha512-sYaq5h4ISdDVZKhA1R0X4NHFg4Kao7HpK3QRfbFcE25/x2PFl4VxlHLZIoBUfv3T3L9g4GVTD376pvArwgGlDA==}
+  '@solidjs/router@2.0.0-next.17':
+    resolution: {integrity: sha512-LchYm3IZ3Y7vGPh/Jx6X8UjpBirQrz9ZoRQkgRpdz8A9C7eTiRXY326pJDcoYDXn7FzYtFpRCwsfBMxRDsFo6A==}
     peerDependencies:
-      '@solidjs/web': ^2.0.0-rc.0
-      solid-js: ^2.0.0-rc.0
+      '@solidjs/web': ^2.0.0-rc.1
+      solid-js: ^2.0.0-rc.1
 
-  '@solidjs/signals@2.0.0-rc.2':
-    resolution: {integrity: sha512-nJyXdBZJaYGqtDuQt8csE9LY9oNZV2fZfPRmJHQT9QjQEuHKQ1OaZScZ8YFaeATrnavzys4Ws95LnUdv8pCidQ==}
+  '@solidjs/signals@2.0.0-rc.3':
+    resolution: {integrity: sha512-/yPhTf3xS1FRR4MX8kTYCd4MjsFxzwkO+KyOTfbu35lTEiaJ4Fxy+JL91XonDzt31GV1mYaZ9CGD2TQIzvXuNA==}
 
   '@solidjs/testing-library@1.0.0-beta.2':
     resolution: {integrity: sha512-TLhQ5IUT/fdDfqa4X2rkQWB28Y+zEwi6mK/TVTeiQlEHG63eK2jfgwNYf2NtQoPh2c3ihLilsCzxABiSTP3JoQ==}
@@ -686,8 +700,8 @@ packages:
       '@solidjs/web': '>=2.0.0'
       solid-js: '>=2.0.0'
 
-  '@solidjs/vite-plugin@3.0.0-next.33':
-    resolution: {integrity: sha512-8c6twAU/ko9TUEr3koPnWQ1CzET+muZPJFaxBSLYv0M+WRgtmbjlHl9GxTSfm5dd23JDwGhBcv3gdxr2slV/wg==}
+  '@solidjs/vite-plugin@3.0.0-next.34':
+    resolution: {integrity: sha512-uDxBcBjbcS6k509TXTsNw4PjubT59eInzLAny43N5Ieoa4jROCaWV+EwxedPqtCF7nsHoKGgwC+ysu6w105G0A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@solidjs/start-devtools': ^1.0.0-next.2
@@ -701,10 +715,10 @@ packages:
       '@testing-library/jest-dom':
         optional: true
 
-  '@solidjs/web@2.0.0-rc.2':
-    resolution: {integrity: sha512-JazuW9NCI+kcpZXRq9J/DAGPmMd0pEWr3kuXFmPZV9tOviiTOHDXOf56pjbUFVDZd+120AKoe/ULmYdSDpJmsA==}
+  '@solidjs/web@2.0.0-rc.3':
+    resolution: {integrity: sha512-5ckKgOjem1pN5ADycOk6TjHmTtjbbN2fukqxo6RW3Oe3H7z0gaXWAdt8dLISto5/O4Nn8VxprFXFWpfy31+DUg==}
     peerDependencies:
-      solid-js: ^2.0.0-rc.2
+      solid-js: ^2.0.0-rc.3
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -864,21 +878,12 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  babel-preset-solid@2.0.0-rc.0:
-    resolution: {integrity: sha512-Ap2/QQY3pICj+Q0VM/RnIOpZo7e6icZnUA0oBJuhqzoCrljqMNo3eFb2OeEa4pUQeFREJOlex4Bt1ggwrcgC8w==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-rc.0
-    peerDependenciesMeta:
-      solid-js:
-        optional: true
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  baseline-browser-mapping@2.11.13:
-    resolution: {integrity: sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==}
+  baseline-browser-mapping@2.11.19:
+    resolution: {integrity: sha512-Grytf1xOxOEMTGRwx6rLGKkTabd4vMg3VrKdj/7joCmV0qgh4QwMMO6xh34YEXQqirAuUdgQGa5orJQQ+69RBw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -899,8 +904,8 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
-  caniuse-lite@1.0.30001809:
-    resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
+  caniuse-lite@1.0.30001810:
+    resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -968,8 +973,8 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  electron-to-chromium@1.5.405:
-    resolution: {integrity: sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==}
+  electron-to-chromium@1.5.415:
+    resolution: {integrity: sha512-958V+Kbhtgz+SxXeEVKBjrlKRBIDAYvUJfwhjxMZ5S6ut9jAl7l9ZKBkBrvjyjZE36PabLUo2L8kEeV5O4vgJg==}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -1549,8 +1554,8 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
-  solid-js@2.0.0-rc.2:
-    resolution: {integrity: sha512-1C++20cho5f+omXbX6MIl+VrBZ+by6QkWpCtpbVmmUR80EGgH4irqV0UdP88GAYHx1U+FzpCcHxIGoA9raCyQA==}
+  solid-js@2.0.0-rc.3:
+    resolution: {integrity: sha512-pmW6bRoTvfp/rN4jN7JmLvSaoIpFt7wm0Hi3j508S/smuJqUbRg3dQEjOPTkAwHW+McYnXrMG7cJ4AMNpLevtQ==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -1939,56 +1944,15 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.42(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
-      '@babel/types': 7.29.8
-      html-entities: 2.3.3
-      parse5: 7.3.0
-      validate-html-nesting: 1.2.4
-
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
-    dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
-      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
-    optional: true
-
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler@0.50.0-next.44':
-    optionalDependencies:
-      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.44
-      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.44
-      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.44
-      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.44
-      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.44
-      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.44
-
   '@emnapi/core@1.11.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/core@1.11.2':
+  '@emnapi/core@1.11.3':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.2
+      '@emnapi/wasi-threads': 1.2.3
       tslib: 2.8.1
     optional: true
 
@@ -1997,12 +1961,17 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.11.2':
+  '@emnapi/runtime@1.11.3':
     dependencies:
       tslib: 2.8.1
     optional: true
 
   '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2079,10 +2048,10 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -2267,34 +2236,81 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@solidjs/meta@1.0.0-next.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)':
+  '@solidjs/babel-plugin@2.0.0-rc.3(@babel/core@7.29.7)':
     dependencies:
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/types': 7.29.8
+      html-entities: 2.3.3
+      parse5: 7.3.0
+      validate-html-nesting: 1.2.4
 
-  '@solidjs/router@2.0.0-next.16(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)':
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3':
     dependencies:
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+    optional: true
 
-  '@solidjs/signals@2.0.0-rc.2': {}
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3':
+    optional: true
 
-  '@solidjs/testing-library@1.0.0-beta.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)':
+  '@solidjs/compiler@2.0.0-rc.3':
+    optionalDependencies:
+      '@solidjs/compiler-darwin-arm64': 2.0.0-rc.3
+      '@solidjs/compiler-darwin-x64': 2.0.0-rc.3
+      '@solidjs/compiler-linux-arm64-gnu': 2.0.0-rc.3
+      '@solidjs/compiler-linux-x64-gnu': 2.0.0-rc.3
+      '@solidjs/compiler-wasm32-wasi': 2.0.0-rc.3
+      '@solidjs/compiler-win32-x64-msvc': 2.0.0-rc.3
+
+  '@solidjs/diagnostics@2.0.0-rc.3(vitest@4.1.10(jsdom@25.0.1)(vite@8.2.1))':
     dependencies:
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
+      '@solidjs/signals': 2.0.0-rc.3
+    optionalDependencies:
+      vitest: 4.1.10(jsdom@25.0.1)(vite@8.2.1)
+
+  '@solidjs/meta@1.0.0-next.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
+    dependencies:
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
+
+  '@solidjs/router@2.0.0-next.17(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
+    dependencies:
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
+
+  '@solidjs/signals@2.0.0-rc.3': {}
+
+  '@solidjs/testing-library@1.0.0-beta.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
+    dependencies:
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@testing-library/dom': 10.4.1
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
 
-  '@solidjs/vite-plugin@3.0.0-next.33(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.2)(vite@8.2.1)':
+  '@solidjs/vite-plugin@3.0.0-next.34(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.3)(vite@8.2.1)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/core': 7.29.7
-      '@dom-expressions/compiler': 0.50.0-next.44
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
+      '@solidjs/babel-plugin': 2.0.0-rc.3(@babel/core@7.29.7)
+      '@solidjs/compiler': 2.0.0-rc.3
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-rc.0(@babel/core@7.29.7)(solid-js@2.0.0-rc.2)
       merge-anything: 5.1.7
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
       vite: 8.2.1
       vitefu: 1.1.3(vite@8.2.1)
     optionalDependencies:
@@ -2302,11 +2318,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2)':
+  '@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3)':
     dependencies:
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -2499,16 +2515,9 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  babel-preset-solid@2.0.0-rc.0(@babel/core@7.29.7)(solid-js@2.0.0-rc.2):
-    dependencies:
-      '@babel/core': 7.29.7
-      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.42(@babel/core@7.29.7)
-    optionalDependencies:
-      solid-js: 2.0.0-rc.2
-
   balanced-match@4.0.4: {}
 
-  baseline-browser-mapping@2.11.13: {}
+  baseline-browser-mapping@2.11.19: {}
 
   brace-expansion@5.0.9:
     dependencies:
@@ -2520,9 +2529,9 @@ snapshots:
 
   browserslist@4.28.8:
     dependencies:
-      baseline-browser-mapping: 2.11.13
-      caniuse-lite: 1.0.30001809
-      electron-to-chromium: 1.5.405
+      baseline-browser-mapping: 2.11.19
+      caniuse-lite: 1.0.30001810
+      electron-to-chromium: 1.5.415
       node-releases: 2.0.53
       update-browserslist-db: 1.3.1(browserslist@4.28.8)
 
@@ -2531,7 +2540,7 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
-  caniuse-lite@1.0.30001809: {}
+  caniuse-lite@1.0.30001810: {}
 
   chai@6.2.2: {}
 
@@ -2585,7 +2594,7 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  electron-to-chromium@1.5.405: {}
+  electron-to-chromium@1.5.415: {}
 
   entities@6.0.1: {}
 
@@ -3171,9 +3180,9 @@ snapshots:
 
   siginfo@2.0.0: {}
 
-  solid-js@2.0.0-rc.2:
+  solid-js@2.0.0-rc.3:
     dependencies:
-      '@solidjs/signals': 2.0.0-rc.2
+      '@solidjs/signals': 2.0.0-rc.3
       csstype: 3.2.3
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)

--- a/solid-v2/basic/vite.config.ts
+++ b/solid-v2/basic/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   plugins: [
     // `extensions` makes @solidjs/vite-plugin also compile the `?pick=` route
     // modules the fileRoutes plugin emits (their ids end in a query string).
-    solid({ start: true, extensions: ['.jsx', '.tsx'] }), // add `ssr: true` for streaming SSR
+    solid({ start: true, extensions: ['.jsx', '.tsx'], diagnostics: true }), // add `ssr: true` for streaming SSR
     fileRoutes({ types: true }),
   ],
   server: {

--- a/solid-v2/fullstack-tanstack/AGENTS.md
+++ b/solid-v2/fullstack-tanstack/AGENTS.md
@@ -1,0 +1,23 @@
+# Agent Guide
+
+This is a SolidJS 2.x project. Solid is not React: components run once (there is no re-render), reactivity is fine-grained through signals, and effects/memos have Solid-specific semantics. Do not port React patterns.
+
+## Versioned skills (in node_modules — read on demand)
+
+The installed packages ship agent skills that match their exact installed versions:
+
+- `node_modules/solid-js/skills/reactivity-diagnostics/SKILL.md` — repair guide mapping every dev-mode diagnostic code (e.g. `REACTIVE_WRITE_IN_OWNED_SCOPE`, `STRICT_READ_UNTRACKED`) to its prescribed fix. Read it whenever a Solid diagnostic code appears in test output or the browser console.
+- `node_modules/@solidjs/diagnostics/skills/agent-loops/SKILL.md` — how to capture reactive evidence (which scopes re-ran and why, wasted recomputes, cost tables) and assert budgets, in tests and against live pages.
+
+## Reactive diagnostics — capture evidence instead of guessing
+
+Use these whenever you are debugging reactivity (something doesn't update, updates too often, or is slow) or verifying a change didn't regress update granularity:
+
+- **In tests:** `captureArtifact()` from `@solidjs/diagnostics` wraps a scenario and returns a serializable artifact of diagnostics + rerun attribution; matchers from `@solidjs/diagnostics/vitest` (`toHaveNoDiagnostics`, `toStayWithinRerunBudget`, `toHaveNoWaste`, …) assert on it. No browser needed.
+- **Against the running dev server** (`diagnostics: true` in vite.config.ts; dev-only, no-op in builds). Requires an open page connected to the dev server (e.g. via a browser tool):
+  - `GET /__solid/diagnostics` — status and connected client count
+  - `POST /__solid/diagnostics` with JSON `{"method":"begin"}` then `{"method":"end"}` — capture a session into an artifact
+  - `{"method":"whyDidRun","params":{"name":"<scope name>"}}` — recorded re-runs of one named scope in the open session
+  - `{"method":"costs"}` — running cost tables for the open session
+
+Name your signals/memos/effects (the `{ name: "..." }` option) — attribution reports scopes by name.

--- a/solid-v2/fullstack-tanstack/package.json
+++ b/solid-v2/fullstack-tanstack/package.json
@@ -13,8 +13,9 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@solidjs/testing-library": "1.0.0-beta.2",
-    "@solidjs/vite-plugin": "^3.0.0-next.33",
+    "@solidjs/diagnostics": "^2.0.0-rc.3",
+    "@solidjs/testing-library": "^1.0.0-beta.2",
+    "@solidjs/vite-plugin": "^3.0.0-next.34",
     "@tanstack/router-plugin": "1.168.27",
     "@testing-library/jest-dom": "^6.6.3",
     "@types/node": "^26.2.0",
@@ -28,10 +29,10 @@
   },
   "dependencies": {
     "@remix-run/cookie": "^0.5.4",
-    "@solidjs/web": "^2.0.0-rc.2",
+    "@solidjs/web": "^2.0.0-rc.3",
+    "@tanstack/solid-query": "^6.0.0-rc.0",
     "@tanstack/solid-router": "^2.0.0-rc.1",
-    "solid-js": "^2.0.0-rc.2",
-    "valibot": "^1.4.2",
-    "@tanstack/solid-query": "^6.0.0-rc.0"
+    "solid-js": "^2.0.0-rc.3",
+    "valibot": "^1.4.2"
   }
 }

--- a/solid-v2/fullstack-tanstack/pnpm-lock.yaml
+++ b/solid-v2/fullstack-tanstack/pnpm-lock.yaml
@@ -12,27 +12,30 @@ importers:
         specifier: ^0.5.4
         version: 0.5.4
       '@solidjs/web':
-        specifier: ^2.0.0-rc.2
-        version: 2.0.0-rc.2(solid-js@2.0.0-rc.2)
+        specifier: ^2.0.0-rc.3
+        version: 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@tanstack/solid-query':
         specifier: ^6.0.0-rc.0
-        version: 6.0.0-rc.0(solid-js@2.0.0-rc.2)
+        version: 6.0.0-rc.0(solid-js@2.0.0-rc.3)
       '@tanstack/solid-router':
         specifier: ^2.0.0-rc.1
-        version: 2.0.0-rc.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)
+        version: 2.0.0-rc.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       solid-js:
-        specifier: ^2.0.0-rc.2
-        version: 2.0.0-rc.2
+        specifier: ^2.0.0-rc.3
+        version: 2.0.0-rc.3
       valibot:
         specifier: ^1.4.2
         version: 1.4.2(typescript@5.9.3)
     devDependencies:
+      '@solidjs/diagnostics':
+        specifier: ^2.0.0-rc.3
+        version: 2.0.0-rc.3(vitest@4.1.10(@types/node@26.2.0)(jsdom@25.0.1)(vite@8.2.1(@types/node@26.2.0)(jiti@2.7.0)))
       '@solidjs/testing-library':
-        specifier: 1.0.0-beta.2
-        version: 1.0.0-beta.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)
+        specifier: ^1.0.0-beta.2
+        version: 1.0.0-beta.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/vite-plugin':
-        specifier: ^3.0.0-next.33
-        version: 3.0.0-next.33(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.2)(vite@8.2.1(@types/node@26.2.0)(jiti@2.7.0))
+        specifier: ^3.0.0-next.34
+        version: 3.0.0-next.34(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.3)(vite@8.2.1(@types/node@26.2.0)(jiti@2.7.0))
       '@tanstack/router-plugin':
         specifier: 1.168.27
         version: 1.168.27(rolldown@1.2.4)(vite@8.2.1(@types/node@26.2.0)(jiti@2.7.0))
@@ -189,59 +192,23 @@ packages:
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.42':
-    resolution: {integrity: sha512-ol24x9RW8loPyOTzC/mQzh/zAsrsPxyTG4WRxxRlwzNK2uBWIBftWN5IwmSV51zDQa7JcT6sE6kkXFCLUvsYIQ==}
-    peerDependencies:
-      '@babel/core': ^7.20.12
-
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
-    resolution: {integrity: sha512-7l575p7EQu16lssfbtgspSBWBSK5+car5NP4VYD/iJiK+Qd2VcMQMwaOjgA1xCs/P0S0l9EFY9BHGIJcHQTL+w==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
-    resolution: {integrity: sha512-NRbfI3HhBPsSrSQvSUfQXvPXfEKjUQKnbBVCDvcu7ISBPMQd+0yH9M+Qmlf7kVq4Ci9qa1HL5EA2jD22d2v73A==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
-    resolution: {integrity: sha512-/Gfa8j/YHBKK1i8b2VQw3ewBlA6qlEZSAn+b7g3z1g18WydPUI/TZWISKpgNxAtyl9m9MvwgbWA1HcHVkf4zyg==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
-    resolution: {integrity: sha512-gV4J4Sr1+6Awnkl5npREqPvxcDfgw4PGguTdFnsHVN9cxAFet3ujcCbWsAJ+QMBUQ8OT/LG6d4oJLlAkQ0D1fA==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
-    resolution: {integrity: sha512-YrzoB/YZtrmnGXhz3sxs7VeuAXT0JRc6NguNX8iDNt5p5fQ0QX+HR75GYMsxY9FceSVTHObrm3fA/8KGYo5z6Q==}
-    engines: {node: '>=14.0.0'}
-
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
-    resolution: {integrity: sha512-BNQEgny4zyjceZqCaRJDCrQ2oy6z7oXruAE/du2uJB7qLz/z24ISJVUKeKHPb5mRzHuSiTlDcK7pDzE7jPPXjg==}
-    cpu: [x64]
-    os: [win32]
-
-  '@dom-expressions/compiler@0.50.0-next.44':
-    resolution: {integrity: sha512-CBj0k+LcpCk8+nJGY7uvqxLC5NLxXTx9l0fuMZBBkBAOgVf5/IlMyMSpaYE5H5AkFiajR05NYvNR07R6e0KZ3w==}
-
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
-  '@emnapi/core@1.11.2':
-    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+  '@emnapi/core@1.11.3':
+    resolution: {integrity: sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==}
 
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
-  '@emnapi/runtime@1.11.2':
-    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@emnapi/wasi-threads@1.2.3':
+    resolution: {integrity: sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==}
 
   '@eslint-community/eslint-utils@4.10.1':
     resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
@@ -755,13 +722,60 @@ packages:
     peerDependencies:
       solid-js: ^1.6.12
 
+  '@solidjs/babel-plugin@2.0.0-rc.3':
+    resolution: {integrity: sha512-VLqCvvMukrACeMuF3uPTyx9l+qCQ9H1G25vOl7FXAdu9rMrLEKZ2IEoiUMczn0mhXAVeplJVEvr7+gSy5m4omA==}
+    peerDependencies:
+      '@babel/core': ^7.20.12
+
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.3':
+    resolution: {integrity: sha512-P9Ngf6KUwM+KGAAUZ40776+1utbk/n3+F+WhyyYm+rUpjO0um9EqBJLvafqEp6kGgSHQ2j5UhioqcuqhesMLbQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.3':
+    resolution: {integrity: sha512-PozalaeiMJxPF7H5ePpqOGM8F9H07sFsSGxyHHZiUn8c4HIBlsacNpc06gUcoJ1xzm7AvayNCV9BJOw2hQYaYg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3':
+    resolution: {integrity: sha512-riY4uwHCqq5vfrlYY7AK8xy/r/Wd98NCnbGqFsDb7bL7TNw398VuA5+hoK4cnsQJe4dqvI2zXFEdmP5xSNAFSQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3':
+    resolution: {integrity: sha512-y2GlcmfIqtWBrxOnvgLsGZvdH2tVK/9JzcFTUzWo5kjoiEy+VCV3NSNcBZrMbLJ7ozIDTiuWePZd/G5LphYdmA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3':
+    resolution: {integrity: sha512-mx7LnrAwKaXd9ZiaAwZeBlMjdWNdmR73F+3I1iOxSpH9Lh2Kyx9IIVff0a1AnwUy17tdDxXMbWxoI/ctYfZsdw==}
+    engines: {node: '>=14.0.0'}
+
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3':
+    resolution: {integrity: sha512-7MQDvdSI42/+lSac6L6WVgCYkUezzliLRoCjo7ultpN2hHy3XgohxvrWfE005OQEMg2pamzzFmfeIl8FUi2JRA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@solidjs/compiler@2.0.0-rc.3':
+    resolution: {integrity: sha512-gu2AnJwkrJfk3SBKGRxEUGuP/SZpwUGzHQS5zt56eNG4GFlEMyurahVRSLMWWBhtC1On7wH5SmLxybH2yDCqAg==}
+
+  '@solidjs/diagnostics@2.0.0-rc.3':
+    resolution: {integrity: sha512-fPb20MXqN7LpT02+kxfMBhY3reCKeh7vB++g9Su1EJZ6Ie0PeydyU/CnkUNa9gwLCMKoZG1x0pfAMb9yLGowtw==}
+    peerDependencies:
+      vitest: '>=2.0.0'
+    peerDependenciesMeta:
+      vitest:
+        optional: true
+
   '@solidjs/meta@0.29.4':
     resolution: {integrity: sha512-zdIWBGpR9zGx1p1bzIPqF5Gs+Ks/BH8R6fWhmUa/dcK1L2rUC8BAcZJzNRYBQv74kScf1TSOs0EY//Vd/I0V8g==}
     peerDependencies:
       solid-js: '>=1.8.4'
 
-  '@solidjs/signals@2.0.0-rc.2':
-    resolution: {integrity: sha512-nJyXdBZJaYGqtDuQt8csE9LY9oNZV2fZfPRmJHQT9QjQEuHKQ1OaZScZ8YFaeATrnavzys4Ws95LnUdv8pCidQ==}
+  '@solidjs/signals@2.0.0-rc.3':
+    resolution: {integrity: sha512-/yPhTf3xS1FRR4MX8kTYCd4MjsFxzwkO+KyOTfbu35lTEiaJ4Fxy+JL91XonDzt31GV1mYaZ9CGD2TQIzvXuNA==}
 
   '@solidjs/testing-library@1.0.0-beta.2':
     resolution: {integrity: sha512-TLhQ5IUT/fdDfqa4X2rkQWB28Y+zEwi6mK/TVTeiQlEHG63eK2jfgwNYf2NtQoPh2c3ihLilsCzxABiSTP3JoQ==}
@@ -770,8 +784,8 @@ packages:
       '@solidjs/web': '>=2.0.0'
       solid-js: '>=2.0.0'
 
-  '@solidjs/vite-plugin@3.0.0-next.33':
-    resolution: {integrity: sha512-8c6twAU/ko9TUEr3koPnWQ1CzET+muZPJFaxBSLYv0M+WRgtmbjlHl9GxTSfm5dd23JDwGhBcv3gdxr2slV/wg==}
+  '@solidjs/vite-plugin@3.0.0-next.34':
+    resolution: {integrity: sha512-uDxBcBjbcS6k509TXTsNw4PjubT59eInzLAny43N5Ieoa4jROCaWV+EwxedPqtCF7nsHoKGgwC+ysu6w105G0A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@solidjs/start-devtools': ^1.0.0-next.2
@@ -785,10 +799,10 @@ packages:
       '@testing-library/jest-dom':
         optional: true
 
-  '@solidjs/web@2.0.0-rc.2':
-    resolution: {integrity: sha512-JazuW9NCI+kcpZXRq9J/DAGPmMd0pEWr3kuXFmPZV9tOviiTOHDXOf56pjbUFVDZd+120AKoe/ULmYdSDpJmsA==}
+  '@solidjs/web@2.0.0-rc.3':
+    resolution: {integrity: sha512-5ckKgOjem1pN5ADycOk6TjHmTtjbbN2fukqxo6RW3Oe3H7z0gaXWAdt8dLISto5/O4Nn8VxprFXFWpfy31+DUg==}
     peerDependencies:
-      solid-js: ^2.0.0-rc.2
+      solid-js: ^2.0.0-rc.3
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1018,21 +1032,12 @@ packages:
   babel-dead-code-elimination@1.0.12:
     resolution: {integrity: sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==}
 
-  babel-preset-solid@2.0.0-rc.0:
-    resolution: {integrity: sha512-Ap2/QQY3pICj+Q0VM/RnIOpZo7e6icZnUA0oBJuhqzoCrljqMNo3eFb2OeEa4pUQeFREJOlex4Bt1ggwrcgC8w==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-rc.0
-    peerDependenciesMeta:
-      solid-js:
-        optional: true
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  baseline-browser-mapping@2.11.13:
-    resolution: {integrity: sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==}
+  baseline-browser-mapping@2.11.19:
+    resolution: {integrity: sha512-Grytf1xOxOEMTGRwx6rLGKkTabd4vMg3VrKdj/7joCmV0qgh4QwMMO6xh34YEXQqirAuUdgQGa5orJQQ+69RBw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1053,8 +1058,8 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
-  caniuse-lite@1.0.30001809:
-    resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
+  caniuse-lite@1.0.30001810:
+    resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -1133,8 +1138,8 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  electron-to-chromium@1.5.405:
-    resolution: {integrity: sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==}
+  electron-to-chromium@1.5.415:
+    resolution: {integrity: sha512-958V+Kbhtgz+SxXeEVKBjrlKRBIDAYvUJfwhjxMZ5S6ut9jAl7l9ZKBkBrvjyjZE36PabLUo2L8kEeV5O4vgJg==}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -1741,8 +1746,8 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
-  solid-js@2.0.0-rc.2:
-    resolution: {integrity: sha512-1C++20cho5f+omXbX6MIl+VrBZ+by6QkWpCtpbVmmUR80EGgH4irqV0UdP88GAYHx1U+FzpCcHxIGoA9raCyQA==}
+  solid-js@2.0.0-rc.3:
+    resolution: {integrity: sha512-pmW6bRoTvfp/rN4jN7JmLvSaoIpFt7wm0Hi3j508S/smuJqUbRg3dQEjOPTkAwHW+McYnXrMG7cJ4AMNpLevtQ==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2181,56 +2186,15 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.42(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
-      '@babel/types': 7.29.8
-      html-entities: 2.3.3
-      parse5: 7.3.0
-      validate-html-nesting: 1.2.4
-
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
-    dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
-      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
-    optional: true
-
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler@0.50.0-next.44':
-    optionalDependencies:
-      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.44
-      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.44
-      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.44
-      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.44
-      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.44
-      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.44
-
   '@emnapi/core@1.11.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/core@1.11.2':
+  '@emnapi/core@1.11.3':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.2
+      '@emnapi/wasi-threads': 1.2.3
       tslib: 2.8.1
     optional: true
 
@@ -2239,12 +2203,17 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.11.2':
+  '@emnapi/runtime@1.11.3':
     dependencies:
       tslib: 2.8.1
     optional: true
 
   '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2321,10 +2290,10 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -2517,127 +2486,174 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@solid-devtools/debugger@0.28.1(solid-js@2.0.0-rc.2)':
+  '@solid-devtools/debugger@0.28.1(solid-js@2.0.0-rc.3)':
     dependencies:
       '@nothing-but/utils': 0.17.0
-      '@solid-devtools/shared': 0.20.0(solid-js@2.0.0-rc.2)
-      '@solid-primitives/bounds': 0.1.7(solid-js@2.0.0-rc.2)
-      '@solid-primitives/event-listener': 2.4.6(solid-js@2.0.0-rc.2)
-      '@solid-primitives/keyboard': 1.3.7(solid-js@2.0.0-rc.2)
-      '@solid-primitives/rootless': 1.5.4(solid-js@2.0.0-rc.2)
-      '@solid-primitives/scheduled': 1.5.3(solid-js@2.0.0-rc.2)
-      '@solid-primitives/static-store': 0.1.4(solid-js@2.0.0-rc.2)
-      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@solid-devtools/shared': 0.20.0(solid-js@2.0.0-rc.3)
+      '@solid-primitives/bounds': 0.1.7(solid-js@2.0.0-rc.3)
+      '@solid-primitives/event-listener': 2.4.6(solid-js@2.0.0-rc.3)
+      '@solid-primitives/keyboard': 1.3.7(solid-js@2.0.0-rc.3)
+      '@solid-primitives/rootless': 1.5.4(solid-js@2.0.0-rc.3)
+      '@solid-primitives/scheduled': 1.5.3(solid-js@2.0.0-rc.3)
+      '@solid-primitives/static-store': 0.1.4(solid-js@2.0.0-rc.3)
+      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
 
-  '@solid-devtools/logger@0.9.11(solid-js@2.0.0-rc.2)':
+  '@solid-devtools/logger@0.9.11(solid-js@2.0.0-rc.3)':
     dependencies:
       '@nothing-but/utils': 0.17.0
-      '@solid-devtools/debugger': 0.28.1(solid-js@2.0.0-rc.2)
-      '@solid-devtools/shared': 0.20.0(solid-js@2.0.0-rc.2)
-      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@solid-devtools/debugger': 0.28.1(solid-js@2.0.0-rc.3)
+      '@solid-devtools/shared': 0.20.0(solid-js@2.0.0-rc.3)
+      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
 
-  '@solid-devtools/shared@0.20.0(solid-js@2.0.0-rc.2)':
+  '@solid-devtools/shared@0.20.0(solid-js@2.0.0-rc.3)':
     dependencies:
       '@nothing-but/utils': 0.17.0
-      '@solid-primitives/event-listener': 2.4.6(solid-js@2.0.0-rc.2)
-      '@solid-primitives/media': 2.3.6(solid-js@2.0.0-rc.2)
-      '@solid-primitives/refs': 1.1.4(solid-js@2.0.0-rc.2)
-      '@solid-primitives/rootless': 1.5.4(solid-js@2.0.0-rc.2)
-      '@solid-primitives/scheduled': 1.5.3(solid-js@2.0.0-rc.2)
-      '@solid-primitives/static-store': 0.1.4(solid-js@2.0.0-rc.2)
-      '@solid-primitives/styles': 0.1.4(solid-js@2.0.0-rc.2)
-      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@solid-primitives/event-listener': 2.4.6(solid-js@2.0.0-rc.3)
+      '@solid-primitives/media': 2.3.6(solid-js@2.0.0-rc.3)
+      '@solid-primitives/refs': 1.1.4(solid-js@2.0.0-rc.3)
+      '@solid-primitives/rootless': 1.5.4(solid-js@2.0.0-rc.3)
+      '@solid-primitives/scheduled': 1.5.3(solid-js@2.0.0-rc.3)
+      '@solid-primitives/static-store': 0.1.4(solid-js@2.0.0-rc.3)
+      '@solid-primitives/styles': 0.1.4(solid-js@2.0.0-rc.3)
+      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
 
-  '@solid-primitives/bounds@0.1.7(solid-js@2.0.0-rc.2)':
+  '@solid-primitives/bounds@0.1.7(solid-js@2.0.0-rc.3)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.6(solid-js@2.0.0-rc.2)
-      '@solid-primitives/resize-observer': 2.2.0(solid-js@2.0.0-rc.2)
-      '@solid-primitives/static-store': 0.1.4(solid-js@2.0.0-rc.2)
-      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@solid-primitives/event-listener': 2.4.6(solid-js@2.0.0-rc.3)
+      '@solid-primitives/resize-observer': 2.2.0(solid-js@2.0.0-rc.3)
+      '@solid-primitives/static-store': 0.1.4(solid-js@2.0.0-rc.3)
+      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
 
-  '@solid-primitives/event-listener@2.4.6(solid-js@2.0.0-rc.2)':
+  '@solid-primitives/event-listener@2.4.6(solid-js@2.0.0-rc.3)':
     dependencies:
-      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
 
-  '@solid-primitives/keyboard@1.3.7(solid-js@2.0.0-rc.2)':
+  '@solid-primitives/keyboard@1.3.7(solid-js@2.0.0-rc.3)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.6(solid-js@2.0.0-rc.2)
-      '@solid-primitives/rootless': 1.5.4(solid-js@2.0.0-rc.2)
-      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@solid-primitives/event-listener': 2.4.6(solid-js@2.0.0-rc.3)
+      '@solid-primitives/rootless': 1.5.4(solid-js@2.0.0-rc.3)
+      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
 
-  '@solid-primitives/media@2.3.6(solid-js@2.0.0-rc.2)':
+  '@solid-primitives/media@2.3.6(solid-js@2.0.0-rc.3)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.6(solid-js@2.0.0-rc.2)
-      '@solid-primitives/rootless': 1.5.4(solid-js@2.0.0-rc.2)
-      '@solid-primitives/static-store': 0.1.4(solid-js@2.0.0-rc.2)
-      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@solid-primitives/event-listener': 2.4.6(solid-js@2.0.0-rc.3)
+      '@solid-primitives/rootless': 1.5.4(solid-js@2.0.0-rc.3)
+      '@solid-primitives/static-store': 0.1.4(solid-js@2.0.0-rc.3)
+      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
 
-  '@solid-primitives/refs@1.1.4(solid-js@2.0.0-rc.2)':
+  '@solid-primitives/refs@1.1.4(solid-js@2.0.0-rc.3)':
     dependencies:
-      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
 
-  '@solid-primitives/resize-observer@2.2.0(solid-js@2.0.0-rc.2)':
+  '@solid-primitives/resize-observer@2.2.0(solid-js@2.0.0-rc.3)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.6(solid-js@2.0.0-rc.2)
-      '@solid-primitives/rootless': 1.5.4(solid-js@2.0.0-rc.2)
-      '@solid-primitives/static-store': 0.1.4(solid-js@2.0.0-rc.2)
-      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@solid-primitives/event-listener': 2.4.6(solid-js@2.0.0-rc.3)
+      '@solid-primitives/rootless': 1.5.4(solid-js@2.0.0-rc.3)
+      '@solid-primitives/static-store': 0.1.4(solid-js@2.0.0-rc.3)
+      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
 
-  '@solid-primitives/rootless@1.5.4(solid-js@2.0.0-rc.2)':
+  '@solid-primitives/rootless@1.5.4(solid-js@2.0.0-rc.3)':
     dependencies:
-      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
 
-  '@solid-primitives/scheduled@1.5.3(solid-js@2.0.0-rc.2)':
+  '@solid-primitives/scheduled@1.5.3(solid-js@2.0.0-rc.3)':
     dependencies:
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
 
-  '@solid-primitives/static-store@0.1.4(solid-js@2.0.0-rc.2)':
+  '@solid-primitives/static-store@0.1.4(solid-js@2.0.0-rc.3)':
     dependencies:
-      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
 
-  '@solid-primitives/styles@0.1.4(solid-js@2.0.0-rc.2)':
+  '@solid-primitives/styles@0.1.4(solid-js@2.0.0-rc.3)':
     dependencies:
-      '@solid-primitives/rootless': 1.5.4(solid-js@2.0.0-rc.2)
-      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@solid-primitives/rootless': 1.5.4(solid-js@2.0.0-rc.3)
+      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
 
-  '@solid-primitives/utils@6.4.1(solid-js@2.0.0-rc.2)':
+  '@solid-primitives/utils@6.4.1(solid-js@2.0.0-rc.3)':
     dependencies:
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
 
-  '@solidjs/meta@0.29.4(solid-js@2.0.0-rc.2)':
+  '@solidjs/babel-plugin@2.0.0-rc.3(@babel/core@7.29.7)':
     dependencies:
-      solid-js: 2.0.0-rc.2
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/types': 7.29.8
+      html-entities: 2.3.3
+      parse5: 7.3.0
+      validate-html-nesting: 1.2.4
 
-  '@solidjs/signals@2.0.0-rc.2': {}
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.3':
+    optional: true
 
-  '@solidjs/testing-library@1.0.0-beta.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)':
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3':
     dependencies:
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+    optional: true
+
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler@2.0.0-rc.3':
+    optionalDependencies:
+      '@solidjs/compiler-darwin-arm64': 2.0.0-rc.3
+      '@solidjs/compiler-darwin-x64': 2.0.0-rc.3
+      '@solidjs/compiler-linux-arm64-gnu': 2.0.0-rc.3
+      '@solidjs/compiler-linux-x64-gnu': 2.0.0-rc.3
+      '@solidjs/compiler-wasm32-wasi': 2.0.0-rc.3
+      '@solidjs/compiler-win32-x64-msvc': 2.0.0-rc.3
+
+  '@solidjs/diagnostics@2.0.0-rc.3(vitest@4.1.10(@types/node@26.2.0)(jsdom@25.0.1)(vite@8.2.1(@types/node@26.2.0)(jiti@2.7.0)))':
+    dependencies:
+      '@solidjs/signals': 2.0.0-rc.3
+    optionalDependencies:
+      vitest: 4.1.10(@types/node@26.2.0)(jsdom@25.0.1)(vite@8.2.1(@types/node@26.2.0)(jiti@2.7.0))
+
+  '@solidjs/meta@0.29.4(solid-js@2.0.0-rc.3)':
+    dependencies:
+      solid-js: 2.0.0-rc.3
+
+  '@solidjs/signals@2.0.0-rc.3': {}
+
+  '@solidjs/testing-library@1.0.0-beta.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
+    dependencies:
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@testing-library/dom': 10.4.1
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
 
-  '@solidjs/vite-plugin@3.0.0-next.33(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.2)(vite@8.2.1(@types/node@26.2.0)(jiti@2.7.0))':
+  '@solidjs/vite-plugin@3.0.0-next.34(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.3)(vite@8.2.1(@types/node@26.2.0)(jiti@2.7.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/core': 7.29.7
-      '@dom-expressions/compiler': 0.50.0-next.44
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
+      '@solidjs/babel-plugin': 2.0.0-rc.3(@babel/core@7.29.7)
+      '@solidjs/compiler': 2.0.0-rc.3
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-rc.0(@babel/core@7.29.7)(solid-js@2.0.0-rc.2)
       merge-anything: 5.1.7
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
       vite: 8.2.1(@types/node@26.2.0)(jiti@2.7.0)
       vitefu: 1.1.3(vite@8.2.1(@types/node@26.2.0)(jiti@2.7.0))
     optionalDependencies:
@@ -2645,11 +2661,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2)':
+  '@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3)':
     dependencies:
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -2720,21 +2736,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/solid-query@6.0.0-rc.0(solid-js@2.0.0-rc.2)':
+  '@tanstack/solid-query@6.0.0-rc.0(solid-js@2.0.0-rc.3)':
     dependencies:
       '@tanstack/query-core': 5.101.0
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
 
-  '@tanstack/solid-router@2.0.0-rc.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)':
+  '@tanstack/solid-router@2.0.0-rc.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
     dependencies:
-      '@solid-devtools/logger': 0.9.11(solid-js@2.0.0-rc.2)
-      '@solid-primitives/refs': 1.1.4(solid-js@2.0.0-rc.2)
-      '@solidjs/meta': 0.29.4(solid-js@2.0.0-rc.2)
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
+      '@solid-devtools/logger': 0.9.11(solid-js@2.0.0-rc.3)
+      '@solid-primitives/refs': 1.1.4(solid-js@2.0.0-rc.3)
+      '@solidjs/meta': 0.29.4(solid-js@2.0.0-rc.3)
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@tanstack/history': 1.162.1
       '@tanstack/router-core': 1.171.22
       isbot: 5.2.1
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
 
   '@tanstack/virtual-file-routes@1.162.0': {}
 
@@ -2942,16 +2958,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-preset-solid@2.0.0-rc.0(@babel/core@7.29.7)(solid-js@2.0.0-rc.2):
-    dependencies:
-      '@babel/core': 7.29.7
-      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.42(@babel/core@7.29.7)
-    optionalDependencies:
-      solid-js: 2.0.0-rc.2
-
   balanced-match@4.0.4: {}
 
-  baseline-browser-mapping@2.11.13: {}
+  baseline-browser-mapping@2.11.19: {}
 
   brace-expansion@5.0.9:
     dependencies:
@@ -2963,9 +2972,9 @@ snapshots:
 
   browserslist@4.28.8:
     dependencies:
-      baseline-browser-mapping: 2.11.13
-      caniuse-lite: 1.0.30001809
-      electron-to-chromium: 1.5.405
+      baseline-browser-mapping: 2.11.19
+      caniuse-lite: 1.0.30001810
+      electron-to-chromium: 1.5.415
       node-releases: 2.0.53
       update-browserslist-db: 1.3.1(browserslist@4.28.8)
 
@@ -2974,7 +2983,7 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
-  caniuse-lite@1.0.30001809: {}
+  caniuse-lite@1.0.30001810: {}
 
   chai@6.2.2: {}
 
@@ -3036,7 +3045,7 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  electron-to-chromium@1.5.405: {}
+  electron-to-chromium@1.5.415: {}
 
   entities@6.0.1: {}
 
@@ -3638,9 +3647,9 @@ snapshots:
 
   siginfo@2.0.0: {}
 
-  solid-js@2.0.0-rc.2:
+  solid-js@2.0.0-rc.3:
     dependencies:
-      '@solidjs/signals': 2.0.0-rc.2
+      '@solidjs/signals': 2.0.0-rc.3
       csstype: 3.2.3
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)

--- a/solid-v2/fullstack-tanstack/vite.config.ts
+++ b/solid-v2/fullstack-tanstack/vite.config.ts
@@ -38,6 +38,9 @@ export default defineConfig({
       // client while server functions, sessions, and API routes keep
       // working. (Tests always compile with the client posture.)
       ssr: true,
+      // Dev-only agent/diagnostics surface: exposes capture control at
+      // /__solid/diagnostics on the dev server (see AGENTS.md). No-op in build.
+      diagnostics: true,
       // Compiles 'use server' functions into fetch calls on the client and
       // serves them from the /_server endpoint. The configure module runs
       // in the handler graph before any dispatch — it registers the Query

--- a/solid-v2/fullstack/AGENTS.md
+++ b/solid-v2/fullstack/AGENTS.md
@@ -1,0 +1,23 @@
+# Agent Guide
+
+This is a SolidJS 2.x project. Solid is not React: components run once (there is no re-render), reactivity is fine-grained through signals, and effects/memos have Solid-specific semantics. Do not port React patterns.
+
+## Versioned skills (in node_modules — read on demand)
+
+The installed packages ship agent skills that match their exact installed versions:
+
+- `node_modules/solid-js/skills/reactivity-diagnostics/SKILL.md` — repair guide mapping every dev-mode diagnostic code (e.g. `REACTIVE_WRITE_IN_OWNED_SCOPE`, `STRICT_READ_UNTRACKED`) to its prescribed fix. Read it whenever a Solid diagnostic code appears in test output or the browser console.
+- `node_modules/@solidjs/diagnostics/skills/agent-loops/SKILL.md` — how to capture reactive evidence (which scopes re-ran and why, wasted recomputes, cost tables) and assert budgets, in tests and against live pages.
+
+## Reactive diagnostics — capture evidence instead of guessing
+
+Use these whenever you are debugging reactivity (something doesn't update, updates too often, or is slow) or verifying a change didn't regress update granularity:
+
+- **In tests:** `captureArtifact()` from `@solidjs/diagnostics` wraps a scenario and returns a serializable artifact of diagnostics + rerun attribution; matchers from `@solidjs/diagnostics/vitest` (`toHaveNoDiagnostics`, `toStayWithinRerunBudget`, `toHaveNoWaste`, …) assert on it. No browser needed.
+- **Against the running dev server** (`diagnostics: true` in vite.config.ts; dev-only, no-op in builds). Requires an open page connected to the dev server (e.g. via a browser tool):
+  - `GET /__solid/diagnostics` — status and connected client count
+  - `POST /__solid/diagnostics` with JSON `{"method":"begin"}` then `{"method":"end"}` — capture a session into an artifact
+  - `{"method":"whyDidRun","params":{"name":"<scope name>"}}` — recorded re-runs of one named scope in the open session
+  - `{"method":"costs"}` — running cost tables for the open session
+
+Name your signals/memos/effects (the `{ name: "..." }` option) — attribution reports scopes by name.

--- a/solid-v2/fullstack/package.json
+++ b/solid-v2/fullstack/package.json
@@ -13,8 +13,9 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@solidjs/testing-library": "1.0.0-beta.2",
-    "@solidjs/vite-plugin": "^3.0.0-next.33",
+    "@solidjs/diagnostics": "^2.0.0-rc.3",
+    "@solidjs/testing-library": "^1.0.0-beta.2",
+    "@solidjs/vite-plugin": "^3.0.0-next.34",
     "@testing-library/jest-dom": "^6.6.3",
     "@types/node": "^26.2.0",
     "eslint-plugin-solid": "~0.16.0",
@@ -28,9 +29,9 @@
   "dependencies": {
     "@remix-run/cookie": "^0.5.4",
     "@solidjs/meta": "^1.0.0-next.2",
-    "@solidjs/router": "^2.0.0-next.16",
-    "@solidjs/web": "^2.0.0-rc.2",
-    "solid-js": "^2.0.0-rc.2",
+    "@solidjs/router": "^2.0.0-next.17",
+    "@solidjs/web": "^2.0.0-rc.3",
+    "solid-js": "^2.0.0-rc.3",
     "valibot": "^1.4.2"
   }
 }

--- a/solid-v2/fullstack/pnpm-lock.yaml
+++ b/solid-v2/fullstack/pnpm-lock.yaml
@@ -13,26 +13,29 @@ importers:
         version: 0.5.4
       '@solidjs/meta':
         specifier: ^1.0.0-next.2
-        version: 1.0.0-next.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)
+        version: 1.0.0-next.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/router':
-        specifier: ^2.0.0-next.16
-        version: 2.0.0-next.16(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)
+        specifier: ^2.0.0-next.17
+        version: 2.0.0-next.17(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/web':
-        specifier: ^2.0.0-rc.2
-        version: 2.0.0-rc.2(solid-js@2.0.0-rc.2)
+        specifier: ^2.0.0-rc.3
+        version: 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       solid-js:
-        specifier: ^2.0.0-rc.2
-        version: 2.0.0-rc.2
+        specifier: ^2.0.0-rc.3
+        version: 2.0.0-rc.3
       valibot:
         specifier: ^1.4.2
         version: 1.4.2(typescript@5.9.3)
     devDependencies:
+      '@solidjs/diagnostics':
+        specifier: ^2.0.0-rc.3
+        version: 2.0.0-rc.3(vitest@4.1.10(@types/node@26.2.0)(jsdom@25.0.1)(vite@8.2.1(@types/node@26.2.0)))
       '@solidjs/testing-library':
-        specifier: 1.0.0-beta.2
-        version: 1.0.0-beta.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)
+        specifier: ^1.0.0-beta.2
+        version: 1.0.0-beta.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/vite-plugin':
-        specifier: ^3.0.0-next.33
-        version: 3.0.0-next.33(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.2)(vite@8.2.1(@types/node@26.2.0))
+        specifier: ^3.0.0-next.34
+        version: 3.0.0-next.34(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.3)(vite@8.2.1(@types/node@26.2.0))
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.10.0(@testing-library/dom@10.4.1)
@@ -186,59 +189,23 @@ packages:
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.42':
-    resolution: {integrity: sha512-ol24x9RW8loPyOTzC/mQzh/zAsrsPxyTG4WRxxRlwzNK2uBWIBftWN5IwmSV51zDQa7JcT6sE6kkXFCLUvsYIQ==}
-    peerDependencies:
-      '@babel/core': ^7.20.12
-
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
-    resolution: {integrity: sha512-7l575p7EQu16lssfbtgspSBWBSK5+car5NP4VYD/iJiK+Qd2VcMQMwaOjgA1xCs/P0S0l9EFY9BHGIJcHQTL+w==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
-    resolution: {integrity: sha512-NRbfI3HhBPsSrSQvSUfQXvPXfEKjUQKnbBVCDvcu7ISBPMQd+0yH9M+Qmlf7kVq4Ci9qa1HL5EA2jD22d2v73A==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
-    resolution: {integrity: sha512-/Gfa8j/YHBKK1i8b2VQw3ewBlA6qlEZSAn+b7g3z1g18WydPUI/TZWISKpgNxAtyl9m9MvwgbWA1HcHVkf4zyg==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
-    resolution: {integrity: sha512-gV4J4Sr1+6Awnkl5npREqPvxcDfgw4PGguTdFnsHVN9cxAFet3ujcCbWsAJ+QMBUQ8OT/LG6d4oJLlAkQ0D1fA==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
-    resolution: {integrity: sha512-YrzoB/YZtrmnGXhz3sxs7VeuAXT0JRc6NguNX8iDNt5p5fQ0QX+HR75GYMsxY9FceSVTHObrm3fA/8KGYo5z6Q==}
-    engines: {node: '>=14.0.0'}
-
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
-    resolution: {integrity: sha512-BNQEgny4zyjceZqCaRJDCrQ2oy6z7oXruAE/du2uJB7qLz/z24ISJVUKeKHPb5mRzHuSiTlDcK7pDzE7jPPXjg==}
-    cpu: [x64]
-    os: [win32]
-
-  '@dom-expressions/compiler@0.50.0-next.44':
-    resolution: {integrity: sha512-CBj0k+LcpCk8+nJGY7uvqxLC5NLxXTx9l0fuMZBBkBAOgVf5/IlMyMSpaYE5H5AkFiajR05NYvNR07R6e0KZ3w==}
-
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
-  '@emnapi/core@1.11.2':
-    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+  '@emnapi/core@1.11.3':
+    resolution: {integrity: sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==}
 
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
-  '@emnapi/runtime@1.11.2':
-    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@emnapi/wasi-threads@1.2.3':
+    resolution: {integrity: sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==}
 
   '@eslint-community/eslint-utils@4.10.1':
     resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
@@ -679,20 +646,67 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@solidjs/babel-plugin@2.0.0-rc.3':
+    resolution: {integrity: sha512-VLqCvvMukrACeMuF3uPTyx9l+qCQ9H1G25vOl7FXAdu9rMrLEKZ2IEoiUMczn0mhXAVeplJVEvr7+gSy5m4omA==}
+    peerDependencies:
+      '@babel/core': ^7.20.12
+
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.3':
+    resolution: {integrity: sha512-P9Ngf6KUwM+KGAAUZ40776+1utbk/n3+F+WhyyYm+rUpjO0um9EqBJLvafqEp6kGgSHQ2j5UhioqcuqhesMLbQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.3':
+    resolution: {integrity: sha512-PozalaeiMJxPF7H5ePpqOGM8F9H07sFsSGxyHHZiUn8c4HIBlsacNpc06gUcoJ1xzm7AvayNCV9BJOw2hQYaYg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3':
+    resolution: {integrity: sha512-riY4uwHCqq5vfrlYY7AK8xy/r/Wd98NCnbGqFsDb7bL7TNw398VuA5+hoK4cnsQJe4dqvI2zXFEdmP5xSNAFSQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3':
+    resolution: {integrity: sha512-y2GlcmfIqtWBrxOnvgLsGZvdH2tVK/9JzcFTUzWo5kjoiEy+VCV3NSNcBZrMbLJ7ozIDTiuWePZd/G5LphYdmA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3':
+    resolution: {integrity: sha512-mx7LnrAwKaXd9ZiaAwZeBlMjdWNdmR73F+3I1iOxSpH9Lh2Kyx9IIVff0a1AnwUy17tdDxXMbWxoI/ctYfZsdw==}
+    engines: {node: '>=14.0.0'}
+
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3':
+    resolution: {integrity: sha512-7MQDvdSI42/+lSac6L6WVgCYkUezzliLRoCjo7ultpN2hHy3XgohxvrWfE005OQEMg2pamzzFmfeIl8FUi2JRA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@solidjs/compiler@2.0.0-rc.3':
+    resolution: {integrity: sha512-gu2AnJwkrJfk3SBKGRxEUGuP/SZpwUGzHQS5zt56eNG4GFlEMyurahVRSLMWWBhtC1On7wH5SmLxybH2yDCqAg==}
+
+  '@solidjs/diagnostics@2.0.0-rc.3':
+    resolution: {integrity: sha512-fPb20MXqN7LpT02+kxfMBhY3reCKeh7vB++g9Su1EJZ6Ie0PeydyU/CnkUNa9gwLCMKoZG1x0pfAMb9yLGowtw==}
+    peerDependencies:
+      vitest: '>=2.0.0'
+    peerDependenciesMeta:
+      vitest:
+        optional: true
+
   '@solidjs/meta@1.0.0-next.2':
     resolution: {integrity: sha512-4aqPczFqDdep4JTAUXfh4nyfq7InbTgimd7NuN6ZWWE29UPv0uR5dyr53yFcf2YgVXjFdX+JGhXtsE0njGL+fA==}
     peerDependencies:
       '@solidjs/web': ^2.0.0-rc.0
       solid-js: ^2.0.0-rc.0
 
-  '@solidjs/router@2.0.0-next.16':
-    resolution: {integrity: sha512-sYaq5h4ISdDVZKhA1R0X4NHFg4Kao7HpK3QRfbFcE25/x2PFl4VxlHLZIoBUfv3T3L9g4GVTD376pvArwgGlDA==}
+  '@solidjs/router@2.0.0-next.17':
+    resolution: {integrity: sha512-LchYm3IZ3Y7vGPh/Jx6X8UjpBirQrz9ZoRQkgRpdz8A9C7eTiRXY326pJDcoYDXn7FzYtFpRCwsfBMxRDsFo6A==}
     peerDependencies:
-      '@solidjs/web': ^2.0.0-rc.0
-      solid-js: ^2.0.0-rc.0
+      '@solidjs/web': ^2.0.0-rc.1
+      solid-js: ^2.0.0-rc.1
 
-  '@solidjs/signals@2.0.0-rc.2':
-    resolution: {integrity: sha512-nJyXdBZJaYGqtDuQt8csE9LY9oNZV2fZfPRmJHQT9QjQEuHKQ1OaZScZ8YFaeATrnavzys4Ws95LnUdv8pCidQ==}
+  '@solidjs/signals@2.0.0-rc.3':
+    resolution: {integrity: sha512-/yPhTf3xS1FRR4MX8kTYCd4MjsFxzwkO+KyOTfbu35lTEiaJ4Fxy+JL91XonDzt31GV1mYaZ9CGD2TQIzvXuNA==}
 
   '@solidjs/testing-library@1.0.0-beta.2':
     resolution: {integrity: sha512-TLhQ5IUT/fdDfqa4X2rkQWB28Y+zEwi6mK/TVTeiQlEHG63eK2jfgwNYf2NtQoPh2c3ihLilsCzxABiSTP3JoQ==}
@@ -701,8 +715,8 @@ packages:
       '@solidjs/web': '>=2.0.0'
       solid-js: '>=2.0.0'
 
-  '@solidjs/vite-plugin@3.0.0-next.33':
-    resolution: {integrity: sha512-8c6twAU/ko9TUEr3koPnWQ1CzET+muZPJFaxBSLYv0M+WRgtmbjlHl9GxTSfm5dd23JDwGhBcv3gdxr2slV/wg==}
+  '@solidjs/vite-plugin@3.0.0-next.34':
+    resolution: {integrity: sha512-uDxBcBjbcS6k509TXTsNw4PjubT59eInzLAny43N5Ieoa4jROCaWV+EwxedPqtCF7nsHoKGgwC+ysu6w105G0A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@solidjs/start-devtools': ^1.0.0-next.2
@@ -716,10 +730,10 @@ packages:
       '@testing-library/jest-dom':
         optional: true
 
-  '@solidjs/web@2.0.0-rc.2':
-    resolution: {integrity: sha512-JazuW9NCI+kcpZXRq9J/DAGPmMd0pEWr3kuXFmPZV9tOviiTOHDXOf56pjbUFVDZd+120AKoe/ULmYdSDpJmsA==}
+  '@solidjs/web@2.0.0-rc.3':
+    resolution: {integrity: sha512-5ckKgOjem1pN5ADycOk6TjHmTtjbbN2fukqxo6RW3Oe3H7z0gaXWAdt8dLISto5/O4Nn8VxprFXFWpfy31+DUg==}
     peerDependencies:
-      solid-js: ^2.0.0-rc.2
+      solid-js: ^2.0.0-rc.3
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -882,21 +896,12 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  babel-preset-solid@2.0.0-rc.0:
-    resolution: {integrity: sha512-Ap2/QQY3pICj+Q0VM/RnIOpZo7e6icZnUA0oBJuhqzoCrljqMNo3eFb2OeEa4pUQeFREJOlex4Bt1ggwrcgC8w==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-rc.0
-    peerDependenciesMeta:
-      solid-js:
-        optional: true
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  baseline-browser-mapping@2.11.13:
-    resolution: {integrity: sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==}
+  baseline-browser-mapping@2.11.19:
+    resolution: {integrity: sha512-Grytf1xOxOEMTGRwx6rLGKkTabd4vMg3VrKdj/7joCmV0qgh4QwMMO6xh34YEXQqirAuUdgQGa5orJQQ+69RBw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -917,8 +922,8 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
-  caniuse-lite@1.0.30001809:
-    resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
+  caniuse-lite@1.0.30001810:
+    resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -986,8 +991,8 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  electron-to-chromium@1.5.405:
-    resolution: {integrity: sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==}
+  electron-to-chromium@1.5.415:
+    resolution: {integrity: sha512-958V+Kbhtgz+SxXeEVKBjrlKRBIDAYvUJfwhjxMZ5S6ut9jAl7l9ZKBkBrvjyjZE36PabLUo2L8kEeV5O4vgJg==}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -1567,8 +1572,8 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
-  solid-js@2.0.0-rc.2:
-    resolution: {integrity: sha512-1C++20cho5f+omXbX6MIl+VrBZ+by6QkWpCtpbVmmUR80EGgH4irqV0UdP88GAYHx1U+FzpCcHxIGoA9raCyQA==}
+  solid-js@2.0.0-rc.3:
+    resolution: {integrity: sha512-pmW6bRoTvfp/rN4jN7JmLvSaoIpFt7wm0Hi3j508S/smuJqUbRg3dQEjOPTkAwHW+McYnXrMG7cJ4AMNpLevtQ==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -1968,56 +1973,15 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.42(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
-      '@babel/types': 7.29.8
-      html-entities: 2.3.3
-      parse5: 7.3.0
-      validate-html-nesting: 1.2.4
-
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
-    dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
-      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
-    optional: true
-
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler@0.50.0-next.44':
-    optionalDependencies:
-      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.44
-      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.44
-      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.44
-      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.44
-      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.44
-      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.44
-
   '@emnapi/core@1.11.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/core@1.11.2':
+  '@emnapi/core@1.11.3':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.2
+      '@emnapi/wasi-threads': 1.2.3
       tslib: 2.8.1
     optional: true
 
@@ -2026,12 +1990,17 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.11.2':
+  '@emnapi/runtime@1.11.3':
     dependencies:
       tslib: 2.8.1
     optional: true
 
   '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2108,10 +2077,10 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -2302,34 +2271,81 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@solidjs/meta@1.0.0-next.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)':
+  '@solidjs/babel-plugin@2.0.0-rc.3(@babel/core@7.29.7)':
     dependencies:
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/types': 7.29.8
+      html-entities: 2.3.3
+      parse5: 7.3.0
+      validate-html-nesting: 1.2.4
 
-  '@solidjs/router@2.0.0-next.16(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)':
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3':
     dependencies:
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+    optional: true
 
-  '@solidjs/signals@2.0.0-rc.2': {}
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3':
+    optional: true
 
-  '@solidjs/testing-library@1.0.0-beta.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)':
+  '@solidjs/compiler@2.0.0-rc.3':
+    optionalDependencies:
+      '@solidjs/compiler-darwin-arm64': 2.0.0-rc.3
+      '@solidjs/compiler-darwin-x64': 2.0.0-rc.3
+      '@solidjs/compiler-linux-arm64-gnu': 2.0.0-rc.3
+      '@solidjs/compiler-linux-x64-gnu': 2.0.0-rc.3
+      '@solidjs/compiler-wasm32-wasi': 2.0.0-rc.3
+      '@solidjs/compiler-win32-x64-msvc': 2.0.0-rc.3
+
+  '@solidjs/diagnostics@2.0.0-rc.3(vitest@4.1.10(@types/node@26.2.0)(jsdom@25.0.1)(vite@8.2.1(@types/node@26.2.0)))':
     dependencies:
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
+      '@solidjs/signals': 2.0.0-rc.3
+    optionalDependencies:
+      vitest: 4.1.10(@types/node@26.2.0)(jsdom@25.0.1)(vite@8.2.1(@types/node@26.2.0))
+
+  '@solidjs/meta@1.0.0-next.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
+    dependencies:
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
+
+  '@solidjs/router@2.0.0-next.17(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
+    dependencies:
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
+
+  '@solidjs/signals@2.0.0-rc.3': {}
+
+  '@solidjs/testing-library@1.0.0-beta.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
+    dependencies:
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@testing-library/dom': 10.4.1
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
 
-  '@solidjs/vite-plugin@3.0.0-next.33(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.2)(vite@8.2.1(@types/node@26.2.0))':
+  '@solidjs/vite-plugin@3.0.0-next.34(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.3)(vite@8.2.1(@types/node@26.2.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/core': 7.29.7
-      '@dom-expressions/compiler': 0.50.0-next.44
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
+      '@solidjs/babel-plugin': 2.0.0-rc.3(@babel/core@7.29.7)
+      '@solidjs/compiler': 2.0.0-rc.3
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-rc.0(@babel/core@7.29.7)(solid-js@2.0.0-rc.2)
       merge-anything: 5.1.7
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
       vite: 8.2.1(@types/node@26.2.0)
       vitefu: 1.1.3(vite@8.2.1(@types/node@26.2.0))
     optionalDependencies:
@@ -2337,11 +2353,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2)':
+  '@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3)':
     dependencies:
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -2538,16 +2554,9 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  babel-preset-solid@2.0.0-rc.0(@babel/core@7.29.7)(solid-js@2.0.0-rc.2):
-    dependencies:
-      '@babel/core': 7.29.7
-      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.42(@babel/core@7.29.7)
-    optionalDependencies:
-      solid-js: 2.0.0-rc.2
-
   balanced-match@4.0.4: {}
 
-  baseline-browser-mapping@2.11.13: {}
+  baseline-browser-mapping@2.11.19: {}
 
   brace-expansion@5.0.9:
     dependencies:
@@ -2559,9 +2568,9 @@ snapshots:
 
   browserslist@4.28.8:
     dependencies:
-      baseline-browser-mapping: 2.11.13
-      caniuse-lite: 1.0.30001809
-      electron-to-chromium: 1.5.405
+      baseline-browser-mapping: 2.11.19
+      caniuse-lite: 1.0.30001810
+      electron-to-chromium: 1.5.415
       node-releases: 2.0.53
       update-browserslist-db: 1.3.1(browserslist@4.28.8)
 
@@ -2570,7 +2579,7 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
-  caniuse-lite@1.0.30001809: {}
+  caniuse-lite@1.0.30001810: {}
 
   chai@6.2.2: {}
 
@@ -2624,7 +2633,7 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  electron-to-chromium@1.5.405: {}
+  electron-to-chromium@1.5.415: {}
 
   entities@6.0.1: {}
 
@@ -3210,9 +3219,9 @@ snapshots:
 
   siginfo@2.0.0: {}
 
-  solid-js@2.0.0-rc.2:
+  solid-js@2.0.0-rc.3:
     dependencies:
-      '@solidjs/signals': 2.0.0-rc.2
+      '@solidjs/signals': 2.0.0-rc.3
       csstype: 3.2.3
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)

--- a/solid-v2/fullstack/vite.config.ts
+++ b/solid-v2/fullstack/vite.config.ts
@@ -22,6 +22,9 @@ export default defineConfig({
       // client while server functions, sessions, and API routes keep
       // working. (Tests always compile with the client posture.)
       ssr: true,
+      // Dev-only agent/diagnostics surface: exposes capture control at
+      // /__solid/diagnostics on the dev server (see AGENTS.md). No-op in build.
+      diagnostics: true,
       // Compiles 'use server' functions into fetch calls on the client and
       // serves them from the /_server endpoint. The configure module runs
       // in the handler graph before any dispatch — it registers the

--- a/solid-v2/with-bootstrap/AGENTS.md
+++ b/solid-v2/with-bootstrap/AGENTS.md
@@ -1,0 +1,23 @@
+# Agent Guide
+
+This is a SolidJS 2.x project. Solid is not React: components run once (there is no re-render), reactivity is fine-grained through signals, and effects/memos have Solid-specific semantics. Do not port React patterns.
+
+## Versioned skills (in node_modules — read on demand)
+
+The installed packages ship agent skills that match their exact installed versions:
+
+- `node_modules/solid-js/skills/reactivity-diagnostics/SKILL.md` — repair guide mapping every dev-mode diagnostic code (e.g. `REACTIVE_WRITE_IN_OWNED_SCOPE`, `STRICT_READ_UNTRACKED`) to its prescribed fix. Read it whenever a Solid diagnostic code appears in test output or the browser console.
+- `node_modules/@solidjs/diagnostics/skills/agent-loops/SKILL.md` — how to capture reactive evidence (which scopes re-ran and why, wasted recomputes, cost tables) and assert budgets, in tests and against live pages.
+
+## Reactive diagnostics — capture evidence instead of guessing
+
+Use these whenever you are debugging reactivity (something doesn't update, updates too often, or is slow) or verifying a change didn't regress update granularity:
+
+- **In tests:** `captureArtifact()` from `@solidjs/diagnostics` wraps a scenario and returns a serializable artifact of diagnostics + rerun attribution; matchers from `@solidjs/diagnostics/vitest` (`toHaveNoDiagnostics`, `toStayWithinRerunBudget`, `toHaveNoWaste`, …) assert on it. No browser needed.
+- **Against the running dev server** (`diagnostics: true` in vite.config.ts; dev-only, no-op in builds). Requires an open page connected to the dev server (e.g. via a browser tool):
+  - `GET /__solid/diagnostics` — status and connected client count
+  - `POST /__solid/diagnostics` with JSON `{"method":"begin"}` then `{"method":"end"}` — capture a session into an artifact
+  - `{"method":"whyDidRun","params":{"name":"<scope name>"}}` — recorded re-runs of one named scope in the open session
+  - `{"method":"costs"}` — running cost tables for the open session
+
+Name your signals/memos/effects (the `{ name: "..." }` option) — attribution reports scopes by name.

--- a/solid-v2/with-bootstrap/package.json
+++ b/solid-v2/with-bootstrap/package.json
@@ -13,8 +13,9 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@solidjs/testing-library": "1.0.0-beta.2",
-    "@solidjs/vite-plugin": "^3.0.0-next.33",
+    "@solidjs/diagnostics": "^2.0.0-rc.3",
+    "@solidjs/testing-library": "^1.0.0-beta.2",
+    "@solidjs/vite-plugin": "^3.0.0-next.34",
     "@testing-library/jest-dom": "^6.6.3",
     "eslint-plugin-solid": "~0.16.0",
     "filesystem-routing": "0.2.1",
@@ -26,9 +27,9 @@
   },
   "dependencies": {
     "@solidjs/meta": "^1.0.0-next.2",
-    "@solidjs/router": "^2.0.0-next.16",
-    "@solidjs/web": "^2.0.0-rc.2",
+    "@solidjs/router": "^2.0.0-next.17",
+    "@solidjs/web": "^2.0.0-rc.3",
     "bootstrap": "^5.3.3",
-    "solid-js": "^2.0.0-rc.2"
+    "solid-js": "^2.0.0-rc.3"
   }
 }

--- a/solid-v2/with-bootstrap/pnpm-lock.yaml
+++ b/solid-v2/with-bootstrap/pnpm-lock.yaml
@@ -10,26 +10,29 @@ importers:
     dependencies:
       '@solidjs/meta':
         specifier: ^1.0.0-next.2
-        version: 1.0.0-next.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)
+        version: 1.0.0-next.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/router':
-        specifier: ^2.0.0-next.16
-        version: 2.0.0-next.16(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)
+        specifier: ^2.0.0-next.17
+        version: 2.0.0-next.17(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/web':
-        specifier: ^2.0.0-rc.2
-        version: 2.0.0-rc.2(solid-js@2.0.0-rc.2)
+        specifier: ^2.0.0-rc.3
+        version: 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       bootstrap:
         specifier: ^5.3.3
         version: 5.3.8(@popperjs/core@2.11.8)
       solid-js:
-        specifier: ^2.0.0-rc.2
-        version: 2.0.0-rc.2
+        specifier: ^2.0.0-rc.3
+        version: 2.0.0-rc.3
     devDependencies:
+      '@solidjs/diagnostics':
+        specifier: ^2.0.0-rc.3
+        version: 2.0.0-rc.3(vitest@4.1.10(jsdom@25.0.1)(vite@8.2.1))
       '@solidjs/testing-library':
-        specifier: 1.0.0-beta.2
-        version: 1.0.0-beta.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)
+        specifier: ^1.0.0-beta.2
+        version: 1.0.0-beta.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/vite-plugin':
-        specifier: ^3.0.0-next.33
-        version: 3.0.0-next.33(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.2)(vite@8.2.1)
+        specifier: ^3.0.0-next.34
+        version: 3.0.0-next.34(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.3)(vite@8.2.1)
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.10.0(@testing-library/dom@10.4.1)
@@ -180,59 +183,23 @@ packages:
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.42':
-    resolution: {integrity: sha512-ol24x9RW8loPyOTzC/mQzh/zAsrsPxyTG4WRxxRlwzNK2uBWIBftWN5IwmSV51zDQa7JcT6sE6kkXFCLUvsYIQ==}
-    peerDependencies:
-      '@babel/core': ^7.20.12
-
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
-    resolution: {integrity: sha512-7l575p7EQu16lssfbtgspSBWBSK5+car5NP4VYD/iJiK+Qd2VcMQMwaOjgA1xCs/P0S0l9EFY9BHGIJcHQTL+w==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
-    resolution: {integrity: sha512-NRbfI3HhBPsSrSQvSUfQXvPXfEKjUQKnbBVCDvcu7ISBPMQd+0yH9M+Qmlf7kVq4Ci9qa1HL5EA2jD22d2v73A==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
-    resolution: {integrity: sha512-/Gfa8j/YHBKK1i8b2VQw3ewBlA6qlEZSAn+b7g3z1g18WydPUI/TZWISKpgNxAtyl9m9MvwgbWA1HcHVkf4zyg==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
-    resolution: {integrity: sha512-gV4J4Sr1+6Awnkl5npREqPvxcDfgw4PGguTdFnsHVN9cxAFet3ujcCbWsAJ+QMBUQ8OT/LG6d4oJLlAkQ0D1fA==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
-    resolution: {integrity: sha512-YrzoB/YZtrmnGXhz3sxs7VeuAXT0JRc6NguNX8iDNt5p5fQ0QX+HR75GYMsxY9FceSVTHObrm3fA/8KGYo5z6Q==}
-    engines: {node: '>=14.0.0'}
-
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
-    resolution: {integrity: sha512-BNQEgny4zyjceZqCaRJDCrQ2oy6z7oXruAE/du2uJB7qLz/z24ISJVUKeKHPb5mRzHuSiTlDcK7pDzE7jPPXjg==}
-    cpu: [x64]
-    os: [win32]
-
-  '@dom-expressions/compiler@0.50.0-next.44':
-    resolution: {integrity: sha512-CBj0k+LcpCk8+nJGY7uvqxLC5NLxXTx9l0fuMZBBkBAOgVf5/IlMyMSpaYE5H5AkFiajR05NYvNR07R6e0KZ3w==}
-
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
-  '@emnapi/core@1.11.2':
-    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+  '@emnapi/core@1.11.3':
+    resolution: {integrity: sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==}
 
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
-  '@emnapi/runtime@1.11.2':
-    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@emnapi/wasi-threads@1.2.3':
+    resolution: {integrity: sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==}
 
   '@eslint-community/eslint-utils@4.10.1':
     resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
@@ -670,20 +637,67 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@solidjs/babel-plugin@2.0.0-rc.3':
+    resolution: {integrity: sha512-VLqCvvMukrACeMuF3uPTyx9l+qCQ9H1G25vOl7FXAdu9rMrLEKZ2IEoiUMczn0mhXAVeplJVEvr7+gSy5m4omA==}
+    peerDependencies:
+      '@babel/core': ^7.20.12
+
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.3':
+    resolution: {integrity: sha512-P9Ngf6KUwM+KGAAUZ40776+1utbk/n3+F+WhyyYm+rUpjO0um9EqBJLvafqEp6kGgSHQ2j5UhioqcuqhesMLbQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.3':
+    resolution: {integrity: sha512-PozalaeiMJxPF7H5ePpqOGM8F9H07sFsSGxyHHZiUn8c4HIBlsacNpc06gUcoJ1xzm7AvayNCV9BJOw2hQYaYg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3':
+    resolution: {integrity: sha512-riY4uwHCqq5vfrlYY7AK8xy/r/Wd98NCnbGqFsDb7bL7TNw398VuA5+hoK4cnsQJe4dqvI2zXFEdmP5xSNAFSQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3':
+    resolution: {integrity: sha512-y2GlcmfIqtWBrxOnvgLsGZvdH2tVK/9JzcFTUzWo5kjoiEy+VCV3NSNcBZrMbLJ7ozIDTiuWePZd/G5LphYdmA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3':
+    resolution: {integrity: sha512-mx7LnrAwKaXd9ZiaAwZeBlMjdWNdmR73F+3I1iOxSpH9Lh2Kyx9IIVff0a1AnwUy17tdDxXMbWxoI/ctYfZsdw==}
+    engines: {node: '>=14.0.0'}
+
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3':
+    resolution: {integrity: sha512-7MQDvdSI42/+lSac6L6WVgCYkUezzliLRoCjo7ultpN2hHy3XgohxvrWfE005OQEMg2pamzzFmfeIl8FUi2JRA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@solidjs/compiler@2.0.0-rc.3':
+    resolution: {integrity: sha512-gu2AnJwkrJfk3SBKGRxEUGuP/SZpwUGzHQS5zt56eNG4GFlEMyurahVRSLMWWBhtC1On7wH5SmLxybH2yDCqAg==}
+
+  '@solidjs/diagnostics@2.0.0-rc.3':
+    resolution: {integrity: sha512-fPb20MXqN7LpT02+kxfMBhY3reCKeh7vB++g9Su1EJZ6Ie0PeydyU/CnkUNa9gwLCMKoZG1x0pfAMb9yLGowtw==}
+    peerDependencies:
+      vitest: '>=2.0.0'
+    peerDependenciesMeta:
+      vitest:
+        optional: true
+
   '@solidjs/meta@1.0.0-next.2':
     resolution: {integrity: sha512-4aqPczFqDdep4JTAUXfh4nyfq7InbTgimd7NuN6ZWWE29UPv0uR5dyr53yFcf2YgVXjFdX+JGhXtsE0njGL+fA==}
     peerDependencies:
       '@solidjs/web': ^2.0.0-rc.0
       solid-js: ^2.0.0-rc.0
 
-  '@solidjs/router@2.0.0-next.16':
-    resolution: {integrity: sha512-sYaq5h4ISdDVZKhA1R0X4NHFg4Kao7HpK3QRfbFcE25/x2PFl4VxlHLZIoBUfv3T3L9g4GVTD376pvArwgGlDA==}
+  '@solidjs/router@2.0.0-next.17':
+    resolution: {integrity: sha512-LchYm3IZ3Y7vGPh/Jx6X8UjpBirQrz9ZoRQkgRpdz8A9C7eTiRXY326pJDcoYDXn7FzYtFpRCwsfBMxRDsFo6A==}
     peerDependencies:
-      '@solidjs/web': ^2.0.0-rc.0
-      solid-js: ^2.0.0-rc.0
+      '@solidjs/web': ^2.0.0-rc.1
+      solid-js: ^2.0.0-rc.1
 
-  '@solidjs/signals@2.0.0-rc.2':
-    resolution: {integrity: sha512-nJyXdBZJaYGqtDuQt8csE9LY9oNZV2fZfPRmJHQT9QjQEuHKQ1OaZScZ8YFaeATrnavzys4Ws95LnUdv8pCidQ==}
+  '@solidjs/signals@2.0.0-rc.3':
+    resolution: {integrity: sha512-/yPhTf3xS1FRR4MX8kTYCd4MjsFxzwkO+KyOTfbu35lTEiaJ4Fxy+JL91XonDzt31GV1mYaZ9CGD2TQIzvXuNA==}
 
   '@solidjs/testing-library@1.0.0-beta.2':
     resolution: {integrity: sha512-TLhQ5IUT/fdDfqa4X2rkQWB28Y+zEwi6mK/TVTeiQlEHG63eK2jfgwNYf2NtQoPh2c3ihLilsCzxABiSTP3JoQ==}
@@ -692,8 +706,8 @@ packages:
       '@solidjs/web': '>=2.0.0'
       solid-js: '>=2.0.0'
 
-  '@solidjs/vite-plugin@3.0.0-next.33':
-    resolution: {integrity: sha512-8c6twAU/ko9TUEr3koPnWQ1CzET+muZPJFaxBSLYv0M+WRgtmbjlHl9GxTSfm5dd23JDwGhBcv3gdxr2slV/wg==}
+  '@solidjs/vite-plugin@3.0.0-next.34':
+    resolution: {integrity: sha512-uDxBcBjbcS6k509TXTsNw4PjubT59eInzLAny43N5Ieoa4jROCaWV+EwxedPqtCF7nsHoKGgwC+ysu6w105G0A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@solidjs/start-devtools': ^1.0.0-next.2
@@ -707,10 +721,10 @@ packages:
       '@testing-library/jest-dom':
         optional: true
 
-  '@solidjs/web@2.0.0-rc.2':
-    resolution: {integrity: sha512-JazuW9NCI+kcpZXRq9J/DAGPmMd0pEWr3kuXFmPZV9tOviiTOHDXOf56pjbUFVDZd+120AKoe/ULmYdSDpJmsA==}
+  '@solidjs/web@2.0.0-rc.3':
+    resolution: {integrity: sha512-5ckKgOjem1pN5ADycOk6TjHmTtjbbN2fukqxo6RW3Oe3H7z0gaXWAdt8dLISto5/O4Nn8VxprFXFWpfy31+DUg==}
     peerDependencies:
-      solid-js: ^2.0.0-rc.2
+      solid-js: ^2.0.0-rc.3
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -870,21 +884,12 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  babel-preset-solid@2.0.0-rc.0:
-    resolution: {integrity: sha512-Ap2/QQY3pICj+Q0VM/RnIOpZo7e6icZnUA0oBJuhqzoCrljqMNo3eFb2OeEa4pUQeFREJOlex4Bt1ggwrcgC8w==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-rc.0
-    peerDependenciesMeta:
-      solid-js:
-        optional: true
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  baseline-browser-mapping@2.11.13:
-    resolution: {integrity: sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==}
+  baseline-browser-mapping@2.11.19:
+    resolution: {integrity: sha512-Grytf1xOxOEMTGRwx6rLGKkTabd4vMg3VrKdj/7joCmV0qgh4QwMMO6xh34YEXQqirAuUdgQGa5orJQQ+69RBw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -910,8 +915,8 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
-  caniuse-lite@1.0.30001809:
-    resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
+  caniuse-lite@1.0.30001810:
+    resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -979,8 +984,8 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  electron-to-chromium@1.5.405:
-    resolution: {integrity: sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==}
+  electron-to-chromium@1.5.415:
+    resolution: {integrity: sha512-958V+Kbhtgz+SxXeEVKBjrlKRBIDAYvUJfwhjxMZ5S6ut9jAl7l9ZKBkBrvjyjZE36PabLUo2L8kEeV5O4vgJg==}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -1560,8 +1565,8 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
-  solid-js@2.0.0-rc.2:
-    resolution: {integrity: sha512-1C++20cho5f+omXbX6MIl+VrBZ+by6QkWpCtpbVmmUR80EGgH4irqV0UdP88GAYHx1U+FzpCcHxIGoA9raCyQA==}
+  solid-js@2.0.0-rc.3:
+    resolution: {integrity: sha512-pmW6bRoTvfp/rN4jN7JmLvSaoIpFt7wm0Hi3j508S/smuJqUbRg3dQEjOPTkAwHW+McYnXrMG7cJ4AMNpLevtQ==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -1950,56 +1955,15 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.42(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
-      '@babel/types': 7.29.8
-      html-entities: 2.3.3
-      parse5: 7.3.0
-      validate-html-nesting: 1.2.4
-
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
-    dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
-      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
-    optional: true
-
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler@0.50.0-next.44':
-    optionalDependencies:
-      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.44
-      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.44
-      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.44
-      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.44
-      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.44
-      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.44
-
   '@emnapi/core@1.11.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/core@1.11.2':
+  '@emnapi/core@1.11.3':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.2
+      '@emnapi/wasi-threads': 1.2.3
       tslib: 2.8.1
     optional: true
 
@@ -2008,12 +1972,17 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.11.2':
+  '@emnapi/runtime@1.11.3':
     dependencies:
       tslib: 2.8.1
     optional: true
 
   '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2090,10 +2059,10 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -2280,34 +2249,81 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@solidjs/meta@1.0.0-next.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)':
+  '@solidjs/babel-plugin@2.0.0-rc.3(@babel/core@7.29.7)':
     dependencies:
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/types': 7.29.8
+      html-entities: 2.3.3
+      parse5: 7.3.0
+      validate-html-nesting: 1.2.4
 
-  '@solidjs/router@2.0.0-next.16(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)':
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3':
     dependencies:
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+    optional: true
 
-  '@solidjs/signals@2.0.0-rc.2': {}
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3':
+    optional: true
 
-  '@solidjs/testing-library@1.0.0-beta.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)':
+  '@solidjs/compiler@2.0.0-rc.3':
+    optionalDependencies:
+      '@solidjs/compiler-darwin-arm64': 2.0.0-rc.3
+      '@solidjs/compiler-darwin-x64': 2.0.0-rc.3
+      '@solidjs/compiler-linux-arm64-gnu': 2.0.0-rc.3
+      '@solidjs/compiler-linux-x64-gnu': 2.0.0-rc.3
+      '@solidjs/compiler-wasm32-wasi': 2.0.0-rc.3
+      '@solidjs/compiler-win32-x64-msvc': 2.0.0-rc.3
+
+  '@solidjs/diagnostics@2.0.0-rc.3(vitest@4.1.10(jsdom@25.0.1)(vite@8.2.1))':
     dependencies:
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
+      '@solidjs/signals': 2.0.0-rc.3
+    optionalDependencies:
+      vitest: 4.1.10(jsdom@25.0.1)(vite@8.2.1)
+
+  '@solidjs/meta@1.0.0-next.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
+    dependencies:
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
+
+  '@solidjs/router@2.0.0-next.17(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
+    dependencies:
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
+
+  '@solidjs/signals@2.0.0-rc.3': {}
+
+  '@solidjs/testing-library@1.0.0-beta.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
+    dependencies:
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@testing-library/dom': 10.4.1
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
 
-  '@solidjs/vite-plugin@3.0.0-next.33(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.2)(vite@8.2.1)':
+  '@solidjs/vite-plugin@3.0.0-next.34(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.3)(vite@8.2.1)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/core': 7.29.7
-      '@dom-expressions/compiler': 0.50.0-next.44
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
+      '@solidjs/babel-plugin': 2.0.0-rc.3(@babel/core@7.29.7)
+      '@solidjs/compiler': 2.0.0-rc.3
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-rc.0(@babel/core@7.29.7)(solid-js@2.0.0-rc.2)
       merge-anything: 5.1.7
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
       vite: 8.2.1
       vitefu: 1.1.3(vite@8.2.1)
     optionalDependencies:
@@ -2315,11 +2331,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2)':
+  '@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3)':
     dependencies:
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -2512,16 +2528,9 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  babel-preset-solid@2.0.0-rc.0(@babel/core@7.29.7)(solid-js@2.0.0-rc.2):
-    dependencies:
-      '@babel/core': 7.29.7
-      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.42(@babel/core@7.29.7)
-    optionalDependencies:
-      solid-js: 2.0.0-rc.2
-
   balanced-match@4.0.4: {}
 
-  baseline-browser-mapping@2.11.13: {}
+  baseline-browser-mapping@2.11.19: {}
 
   bootstrap@5.3.8(@popperjs/core@2.11.8):
     dependencies:
@@ -2537,9 +2546,9 @@ snapshots:
 
   browserslist@4.28.8:
     dependencies:
-      baseline-browser-mapping: 2.11.13
-      caniuse-lite: 1.0.30001809
-      electron-to-chromium: 1.5.405
+      baseline-browser-mapping: 2.11.19
+      caniuse-lite: 1.0.30001810
+      electron-to-chromium: 1.5.415
       node-releases: 2.0.53
       update-browserslist-db: 1.3.1(browserslist@4.28.8)
 
@@ -2548,7 +2557,7 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
-  caniuse-lite@1.0.30001809: {}
+  caniuse-lite@1.0.30001810: {}
 
   chai@6.2.2: {}
 
@@ -2602,7 +2611,7 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  electron-to-chromium@1.5.405: {}
+  electron-to-chromium@1.5.415: {}
 
   entities@6.0.1: {}
 
@@ -3188,9 +3197,9 @@ snapshots:
 
   siginfo@2.0.0: {}
 
-  solid-js@2.0.0-rc.2:
+  solid-js@2.0.0-rc.3:
     dependencies:
-      '@solidjs/signals': 2.0.0-rc.2
+      '@solidjs/signals': 2.0.0-rc.3
       csstype: 3.2.3
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)

--- a/solid-v2/with-bootstrap/vite.config.ts
+++ b/solid-v2/with-bootstrap/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   plugins: [
     // `extensions` makes @solidjs/vite-plugin also compile the `?pick=` route
     // modules the fileRoutes plugin emits (their ids end in a query string).
-    solid({ start: true, extensions: ['.jsx', '.tsx'] }), // add `ssr: true` for streaming SSR
+    solid({ start: true, extensions: ['.jsx', '.tsx'], diagnostics: true }), // add `ssr: true` for streaming SSR
     fileRoutes({ types: true }),
   ],
   server: {

--- a/solid-v2/with-sass/AGENTS.md
+++ b/solid-v2/with-sass/AGENTS.md
@@ -1,0 +1,23 @@
+# Agent Guide
+
+This is a SolidJS 2.x project. Solid is not React: components run once (there is no re-render), reactivity is fine-grained through signals, and effects/memos have Solid-specific semantics. Do not port React patterns.
+
+## Versioned skills (in node_modules — read on demand)
+
+The installed packages ship agent skills that match their exact installed versions:
+
+- `node_modules/solid-js/skills/reactivity-diagnostics/SKILL.md` — repair guide mapping every dev-mode diagnostic code (e.g. `REACTIVE_WRITE_IN_OWNED_SCOPE`, `STRICT_READ_UNTRACKED`) to its prescribed fix. Read it whenever a Solid diagnostic code appears in test output or the browser console.
+- `node_modules/@solidjs/diagnostics/skills/agent-loops/SKILL.md` — how to capture reactive evidence (which scopes re-ran and why, wasted recomputes, cost tables) and assert budgets, in tests and against live pages.
+
+## Reactive diagnostics — capture evidence instead of guessing
+
+Use these whenever you are debugging reactivity (something doesn't update, updates too often, or is slow) or verifying a change didn't regress update granularity:
+
+- **In tests:** `captureArtifact()` from `@solidjs/diagnostics` wraps a scenario and returns a serializable artifact of diagnostics + rerun attribution; matchers from `@solidjs/diagnostics/vitest` (`toHaveNoDiagnostics`, `toStayWithinRerunBudget`, `toHaveNoWaste`, …) assert on it. No browser needed.
+- **Against the running dev server** (`diagnostics: true` in vite.config.ts; dev-only, no-op in builds). Requires an open page connected to the dev server (e.g. via a browser tool):
+  - `GET /__solid/diagnostics` — status and connected client count
+  - `POST /__solid/diagnostics` with JSON `{"method":"begin"}` then `{"method":"end"}` — capture a session into an artifact
+  - `{"method":"whyDidRun","params":{"name":"<scope name>"}}` — recorded re-runs of one named scope in the open session
+  - `{"method":"costs"}` — running cost tables for the open session
+
+Name your signals/memos/effects (the `{ name: "..." }` option) — attribution reports scopes by name.

--- a/solid-v2/with-sass/package.json
+++ b/solid-v2/with-sass/package.json
@@ -13,8 +13,9 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@solidjs/testing-library": "1.0.0-beta.2",
-    "@solidjs/vite-plugin": "^3.0.0-next.33",
+    "@solidjs/diagnostics": "^2.0.0-rc.3",
+    "@solidjs/testing-library": "^1.0.0-beta.2",
+    "@solidjs/vite-plugin": "^3.0.0-next.34",
     "@testing-library/jest-dom": "^6.6.3",
     "eslint-plugin-solid": "~0.16.0",
     "filesystem-routing": "0.2.1",
@@ -27,8 +28,8 @@
   },
   "dependencies": {
     "@solidjs/meta": "^1.0.0-next.2",
-    "@solidjs/router": "^2.0.0-next.16",
-    "@solidjs/web": "^2.0.0-rc.2",
-    "solid-js": "^2.0.0-rc.2"
+    "@solidjs/router": "^2.0.0-next.17",
+    "@solidjs/web": "^2.0.0-rc.3",
+    "solid-js": "^2.0.0-rc.3"
   }
 }

--- a/solid-v2/with-sass/pnpm-lock.yaml
+++ b/solid-v2/with-sass/pnpm-lock.yaml
@@ -10,23 +10,26 @@ importers:
     dependencies:
       '@solidjs/meta':
         specifier: ^1.0.0-next.2
-        version: 1.0.0-next.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)
+        version: 1.0.0-next.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/router':
-        specifier: ^2.0.0-next.16
-        version: 2.0.0-next.16(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)
+        specifier: ^2.0.0-next.17
+        version: 2.0.0-next.17(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/web':
-        specifier: ^2.0.0-rc.2
-        version: 2.0.0-rc.2(solid-js@2.0.0-rc.2)
+        specifier: ^2.0.0-rc.3
+        version: 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       solid-js:
-        specifier: ^2.0.0-rc.2
-        version: 2.0.0-rc.2
+        specifier: ^2.0.0-rc.3
+        version: 2.0.0-rc.3
     devDependencies:
+      '@solidjs/diagnostics':
+        specifier: ^2.0.0-rc.3
+        version: 2.0.0-rc.3(vitest@4.1.10(jsdom@25.0.1)(vite@8.2.1(sass@1.102.0)))
       '@solidjs/testing-library':
-        specifier: 1.0.0-beta.2
-        version: 1.0.0-beta.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)
+        specifier: ^1.0.0-beta.2
+        version: 1.0.0-beta.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/vite-plugin':
-        specifier: ^3.0.0-next.33
-        version: 3.0.0-next.33(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.2)(vite@8.2.1(sass@1.102.0))
+        specifier: ^3.0.0-next.34
+        version: 3.0.0-next.34(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.3)(vite@8.2.1(sass@1.102.0))
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.10.0(@testing-library/dom@10.4.1)
@@ -180,59 +183,23 @@ packages:
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.42':
-    resolution: {integrity: sha512-ol24x9RW8loPyOTzC/mQzh/zAsrsPxyTG4WRxxRlwzNK2uBWIBftWN5IwmSV51zDQa7JcT6sE6kkXFCLUvsYIQ==}
-    peerDependencies:
-      '@babel/core': ^7.20.12
-
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
-    resolution: {integrity: sha512-7l575p7EQu16lssfbtgspSBWBSK5+car5NP4VYD/iJiK+Qd2VcMQMwaOjgA1xCs/P0S0l9EFY9BHGIJcHQTL+w==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
-    resolution: {integrity: sha512-NRbfI3HhBPsSrSQvSUfQXvPXfEKjUQKnbBVCDvcu7ISBPMQd+0yH9M+Qmlf7kVq4Ci9qa1HL5EA2jD22d2v73A==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
-    resolution: {integrity: sha512-/Gfa8j/YHBKK1i8b2VQw3ewBlA6qlEZSAn+b7g3z1g18WydPUI/TZWISKpgNxAtyl9m9MvwgbWA1HcHVkf4zyg==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
-    resolution: {integrity: sha512-gV4J4Sr1+6Awnkl5npREqPvxcDfgw4PGguTdFnsHVN9cxAFet3ujcCbWsAJ+QMBUQ8OT/LG6d4oJLlAkQ0D1fA==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
-    resolution: {integrity: sha512-YrzoB/YZtrmnGXhz3sxs7VeuAXT0JRc6NguNX8iDNt5p5fQ0QX+HR75GYMsxY9FceSVTHObrm3fA/8KGYo5z6Q==}
-    engines: {node: '>=14.0.0'}
-
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
-    resolution: {integrity: sha512-BNQEgny4zyjceZqCaRJDCrQ2oy6z7oXruAE/du2uJB7qLz/z24ISJVUKeKHPb5mRzHuSiTlDcK7pDzE7jPPXjg==}
-    cpu: [x64]
-    os: [win32]
-
-  '@dom-expressions/compiler@0.50.0-next.44':
-    resolution: {integrity: sha512-CBj0k+LcpCk8+nJGY7uvqxLC5NLxXTx9l0fuMZBBkBAOgVf5/IlMyMSpaYE5H5AkFiajR05NYvNR07R6e0KZ3w==}
-
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
-  '@emnapi/core@1.11.2':
-    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+  '@emnapi/core@1.11.3':
+    resolution: {integrity: sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==}
 
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
-  '@emnapi/runtime@1.11.2':
-    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@emnapi/wasi-threads@1.2.3':
+    resolution: {integrity: sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==}
 
   '@eslint-community/eslint-utils@4.10.1':
     resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
@@ -749,20 +716,67 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@solidjs/babel-plugin@2.0.0-rc.3':
+    resolution: {integrity: sha512-VLqCvvMukrACeMuF3uPTyx9l+qCQ9H1G25vOl7FXAdu9rMrLEKZ2IEoiUMczn0mhXAVeplJVEvr7+gSy5m4omA==}
+    peerDependencies:
+      '@babel/core': ^7.20.12
+
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.3':
+    resolution: {integrity: sha512-P9Ngf6KUwM+KGAAUZ40776+1utbk/n3+F+WhyyYm+rUpjO0um9EqBJLvafqEp6kGgSHQ2j5UhioqcuqhesMLbQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.3':
+    resolution: {integrity: sha512-PozalaeiMJxPF7H5ePpqOGM8F9H07sFsSGxyHHZiUn8c4HIBlsacNpc06gUcoJ1xzm7AvayNCV9BJOw2hQYaYg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3':
+    resolution: {integrity: sha512-riY4uwHCqq5vfrlYY7AK8xy/r/Wd98NCnbGqFsDb7bL7TNw398VuA5+hoK4cnsQJe4dqvI2zXFEdmP5xSNAFSQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3':
+    resolution: {integrity: sha512-y2GlcmfIqtWBrxOnvgLsGZvdH2tVK/9JzcFTUzWo5kjoiEy+VCV3NSNcBZrMbLJ7ozIDTiuWePZd/G5LphYdmA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3':
+    resolution: {integrity: sha512-mx7LnrAwKaXd9ZiaAwZeBlMjdWNdmR73F+3I1iOxSpH9Lh2Kyx9IIVff0a1AnwUy17tdDxXMbWxoI/ctYfZsdw==}
+    engines: {node: '>=14.0.0'}
+
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3':
+    resolution: {integrity: sha512-7MQDvdSI42/+lSac6L6WVgCYkUezzliLRoCjo7ultpN2hHy3XgohxvrWfE005OQEMg2pamzzFmfeIl8FUi2JRA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@solidjs/compiler@2.0.0-rc.3':
+    resolution: {integrity: sha512-gu2AnJwkrJfk3SBKGRxEUGuP/SZpwUGzHQS5zt56eNG4GFlEMyurahVRSLMWWBhtC1On7wH5SmLxybH2yDCqAg==}
+
+  '@solidjs/diagnostics@2.0.0-rc.3':
+    resolution: {integrity: sha512-fPb20MXqN7LpT02+kxfMBhY3reCKeh7vB++g9Su1EJZ6Ie0PeydyU/CnkUNa9gwLCMKoZG1x0pfAMb9yLGowtw==}
+    peerDependencies:
+      vitest: '>=2.0.0'
+    peerDependenciesMeta:
+      vitest:
+        optional: true
+
   '@solidjs/meta@1.0.0-next.2':
     resolution: {integrity: sha512-4aqPczFqDdep4JTAUXfh4nyfq7InbTgimd7NuN6ZWWE29UPv0uR5dyr53yFcf2YgVXjFdX+JGhXtsE0njGL+fA==}
     peerDependencies:
       '@solidjs/web': ^2.0.0-rc.0
       solid-js: ^2.0.0-rc.0
 
-  '@solidjs/router@2.0.0-next.16':
-    resolution: {integrity: sha512-sYaq5h4ISdDVZKhA1R0X4NHFg4Kao7HpK3QRfbFcE25/x2PFl4VxlHLZIoBUfv3T3L9g4GVTD376pvArwgGlDA==}
+  '@solidjs/router@2.0.0-next.17':
+    resolution: {integrity: sha512-LchYm3IZ3Y7vGPh/Jx6X8UjpBirQrz9ZoRQkgRpdz8A9C7eTiRXY326pJDcoYDXn7FzYtFpRCwsfBMxRDsFo6A==}
     peerDependencies:
-      '@solidjs/web': ^2.0.0-rc.0
-      solid-js: ^2.0.0-rc.0
+      '@solidjs/web': ^2.0.0-rc.1
+      solid-js: ^2.0.0-rc.1
 
-  '@solidjs/signals@2.0.0-rc.2':
-    resolution: {integrity: sha512-nJyXdBZJaYGqtDuQt8csE9LY9oNZV2fZfPRmJHQT9QjQEuHKQ1OaZScZ8YFaeATrnavzys4Ws95LnUdv8pCidQ==}
+  '@solidjs/signals@2.0.0-rc.3':
+    resolution: {integrity: sha512-/yPhTf3xS1FRR4MX8kTYCd4MjsFxzwkO+KyOTfbu35lTEiaJ4Fxy+JL91XonDzt31GV1mYaZ9CGD2TQIzvXuNA==}
 
   '@solidjs/testing-library@1.0.0-beta.2':
     resolution: {integrity: sha512-TLhQ5IUT/fdDfqa4X2rkQWB28Y+zEwi6mK/TVTeiQlEHG63eK2jfgwNYf2NtQoPh2c3ihLilsCzxABiSTP3JoQ==}
@@ -771,8 +785,8 @@ packages:
       '@solidjs/web': '>=2.0.0'
       solid-js: '>=2.0.0'
 
-  '@solidjs/vite-plugin@3.0.0-next.33':
-    resolution: {integrity: sha512-8c6twAU/ko9TUEr3koPnWQ1CzET+muZPJFaxBSLYv0M+WRgtmbjlHl9GxTSfm5dd23JDwGhBcv3gdxr2slV/wg==}
+  '@solidjs/vite-plugin@3.0.0-next.34':
+    resolution: {integrity: sha512-uDxBcBjbcS6k509TXTsNw4PjubT59eInzLAny43N5Ieoa4jROCaWV+EwxedPqtCF7nsHoKGgwC+ysu6w105G0A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@solidjs/start-devtools': ^1.0.0-next.2
@@ -786,10 +800,10 @@ packages:
       '@testing-library/jest-dom':
         optional: true
 
-  '@solidjs/web@2.0.0-rc.2':
-    resolution: {integrity: sha512-JazuW9NCI+kcpZXRq9J/DAGPmMd0pEWr3kuXFmPZV9tOviiTOHDXOf56pjbUFVDZd+120AKoe/ULmYdSDpJmsA==}
+  '@solidjs/web@2.0.0-rc.3':
+    resolution: {integrity: sha512-5ckKgOjem1pN5ADycOk6TjHmTtjbbN2fukqxo6RW3Oe3H7z0gaXWAdt8dLISto5/O4Nn8VxprFXFWpfy31+DUg==}
     peerDependencies:
-      solid-js: ^2.0.0-rc.2
+      solid-js: ^2.0.0-rc.3
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -949,21 +963,12 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  babel-preset-solid@2.0.0-rc.0:
-    resolution: {integrity: sha512-Ap2/QQY3pICj+Q0VM/RnIOpZo7e6icZnUA0oBJuhqzoCrljqMNo3eFb2OeEa4pUQeFREJOlex4Bt1ggwrcgC8w==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-rc.0
-    peerDependenciesMeta:
-      solid-js:
-        optional: true
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  baseline-browser-mapping@2.11.13:
-    resolution: {integrity: sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==}
+  baseline-browser-mapping@2.11.19:
+    resolution: {integrity: sha512-Grytf1xOxOEMTGRwx6rLGKkTabd4vMg3VrKdj/7joCmV0qgh4QwMMO6xh34YEXQqirAuUdgQGa5orJQQ+69RBw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -984,8 +989,8 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
-  caniuse-lite@1.0.30001809:
-    resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
+  caniuse-lite@1.0.30001810:
+    resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -1057,8 +1062,8 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  electron-to-chromium@1.5.405:
-    resolution: {integrity: sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==}
+  electron-to-chromium@1.5.415:
+    resolution: {integrity: sha512-958V+Kbhtgz+SxXeEVKBjrlKRBIDAYvUJfwhjxMZ5S6ut9jAl7l9ZKBkBrvjyjZE36PabLUo2L8kEeV5O4vgJg==}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -1653,8 +1658,8 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
-  solid-js@2.0.0-rc.2:
-    resolution: {integrity: sha512-1C++20cho5f+omXbX6MIl+VrBZ+by6QkWpCtpbVmmUR80EGgH4irqV0UdP88GAYHx1U+FzpCcHxIGoA9raCyQA==}
+  solid-js@2.0.0-rc.3:
+    resolution: {integrity: sha512-pmW6bRoTvfp/rN4jN7JmLvSaoIpFt7wm0Hi3j508S/smuJqUbRg3dQEjOPTkAwHW+McYnXrMG7cJ4AMNpLevtQ==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2043,56 +2048,15 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.42(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
-      '@babel/types': 7.29.8
-      html-entities: 2.3.3
-      parse5: 7.3.0
-      validate-html-nesting: 1.2.4
-
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
-    dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
-      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
-    optional: true
-
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler@0.50.0-next.44':
-    optionalDependencies:
-      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.44
-      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.44
-      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.44
-      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.44
-      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.44
-      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.44
-
   '@emnapi/core@1.11.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/core@1.11.2':
+  '@emnapi/core@1.11.3':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.2
+      '@emnapi/wasi-threads': 1.2.3
       tslib: 2.8.1
     optional: true
 
@@ -2101,12 +2065,17 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.11.2':
+  '@emnapi/runtime@1.11.3':
     dependencies:
       tslib: 2.8.1
     optional: true
 
   '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2183,10 +2152,10 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -2428,34 +2397,81 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@solidjs/meta@1.0.0-next.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)':
+  '@solidjs/babel-plugin@2.0.0-rc.3(@babel/core@7.29.7)':
     dependencies:
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/types': 7.29.8
+      html-entities: 2.3.3
+      parse5: 7.3.0
+      validate-html-nesting: 1.2.4
 
-  '@solidjs/router@2.0.0-next.16(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)':
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3':
     dependencies:
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+    optional: true
 
-  '@solidjs/signals@2.0.0-rc.2': {}
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3':
+    optional: true
 
-  '@solidjs/testing-library@1.0.0-beta.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)':
+  '@solidjs/compiler@2.0.0-rc.3':
+    optionalDependencies:
+      '@solidjs/compiler-darwin-arm64': 2.0.0-rc.3
+      '@solidjs/compiler-darwin-x64': 2.0.0-rc.3
+      '@solidjs/compiler-linux-arm64-gnu': 2.0.0-rc.3
+      '@solidjs/compiler-linux-x64-gnu': 2.0.0-rc.3
+      '@solidjs/compiler-wasm32-wasi': 2.0.0-rc.3
+      '@solidjs/compiler-win32-x64-msvc': 2.0.0-rc.3
+
+  '@solidjs/diagnostics@2.0.0-rc.3(vitest@4.1.10(jsdom@25.0.1)(vite@8.2.1(sass@1.102.0)))':
     dependencies:
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
+      '@solidjs/signals': 2.0.0-rc.3
+    optionalDependencies:
+      vitest: 4.1.10(jsdom@25.0.1)(vite@8.2.1(sass@1.102.0))
+
+  '@solidjs/meta@1.0.0-next.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
+    dependencies:
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
+
+  '@solidjs/router@2.0.0-next.17(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
+    dependencies:
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
+
+  '@solidjs/signals@2.0.0-rc.3': {}
+
+  '@solidjs/testing-library@1.0.0-beta.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
+    dependencies:
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@testing-library/dom': 10.4.1
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
 
-  '@solidjs/vite-plugin@3.0.0-next.33(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.2)(vite@8.2.1(sass@1.102.0))':
+  '@solidjs/vite-plugin@3.0.0-next.34(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.3)(vite@8.2.1(sass@1.102.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/core': 7.29.7
-      '@dom-expressions/compiler': 0.50.0-next.44
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
+      '@solidjs/babel-plugin': 2.0.0-rc.3(@babel/core@7.29.7)
+      '@solidjs/compiler': 2.0.0-rc.3
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-rc.0(@babel/core@7.29.7)(solid-js@2.0.0-rc.2)
       merge-anything: 5.1.7
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
       vite: 8.2.1(sass@1.102.0)
       vitefu: 1.1.3(vite@8.2.1(sass@1.102.0))
     optionalDependencies:
@@ -2463,11 +2479,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2)':
+  '@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3)':
     dependencies:
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -2660,16 +2676,9 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  babel-preset-solid@2.0.0-rc.0(@babel/core@7.29.7)(solid-js@2.0.0-rc.2):
-    dependencies:
-      '@babel/core': 7.29.7
-      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.42(@babel/core@7.29.7)
-    optionalDependencies:
-      solid-js: 2.0.0-rc.2
-
   balanced-match@4.0.4: {}
 
-  baseline-browser-mapping@2.11.13: {}
+  baseline-browser-mapping@2.11.19: {}
 
   brace-expansion@5.0.9:
     dependencies:
@@ -2681,9 +2690,9 @@ snapshots:
 
   browserslist@4.28.8:
     dependencies:
-      baseline-browser-mapping: 2.11.13
-      caniuse-lite: 1.0.30001809
-      electron-to-chromium: 1.5.405
+      baseline-browser-mapping: 2.11.19
+      caniuse-lite: 1.0.30001810
+      electron-to-chromium: 1.5.415
       node-releases: 2.0.53
       update-browserslist-db: 1.3.1(browserslist@4.28.8)
 
@@ -2692,7 +2701,7 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
-  caniuse-lite@1.0.30001809: {}
+  caniuse-lite@1.0.30001810: {}
 
   chai@6.2.2: {}
 
@@ -2750,7 +2759,7 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  electron-to-chromium@1.5.405: {}
+  electron-to-chromium@1.5.415: {}
 
   entities@6.0.1: {}
 
@@ -3351,9 +3360,9 @@ snapshots:
 
   siginfo@2.0.0: {}
 
-  solid-js@2.0.0-rc.2:
+  solid-js@2.0.0-rc.3:
     dependencies:
-      '@solidjs/signals': 2.0.0-rc.2
+      '@solidjs/signals': 2.0.0-rc.3
       csstype: 3.2.3
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)

--- a/solid-v2/with-sass/vite.config.ts
+++ b/solid-v2/with-sass/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   plugins: [
     // `extensions` makes @solidjs/vite-plugin also compile the `?pick=` route
     // modules the fileRoutes plugin emits (their ids end in a query string).
-    solid({ start: true, extensions: ['.jsx', '.tsx'] }), // add `ssr: true` for streaming SSR
+    solid({ start: true, extensions: ['.jsx', '.tsx'], diagnostics: true }), // add `ssr: true` for streaming SSR
     fileRoutes({ types: true }),
   ],
   server: {

--- a/solid-v2/with-tailwindcss/AGENTS.md
+++ b/solid-v2/with-tailwindcss/AGENTS.md
@@ -1,0 +1,23 @@
+# Agent Guide
+
+This is a SolidJS 2.x project. Solid is not React: components run once (there is no re-render), reactivity is fine-grained through signals, and effects/memos have Solid-specific semantics. Do not port React patterns.
+
+## Versioned skills (in node_modules — read on demand)
+
+The installed packages ship agent skills that match their exact installed versions:
+
+- `node_modules/solid-js/skills/reactivity-diagnostics/SKILL.md` — repair guide mapping every dev-mode diagnostic code (e.g. `REACTIVE_WRITE_IN_OWNED_SCOPE`, `STRICT_READ_UNTRACKED`) to its prescribed fix. Read it whenever a Solid diagnostic code appears in test output or the browser console.
+- `node_modules/@solidjs/diagnostics/skills/agent-loops/SKILL.md` — how to capture reactive evidence (which scopes re-ran and why, wasted recomputes, cost tables) and assert budgets, in tests and against live pages.
+
+## Reactive diagnostics — capture evidence instead of guessing
+
+Use these whenever you are debugging reactivity (something doesn't update, updates too often, or is slow) or verifying a change didn't regress update granularity:
+
+- **In tests:** `captureArtifact()` from `@solidjs/diagnostics` wraps a scenario and returns a serializable artifact of diagnostics + rerun attribution; matchers from `@solidjs/diagnostics/vitest` (`toHaveNoDiagnostics`, `toStayWithinRerunBudget`, `toHaveNoWaste`, …) assert on it. No browser needed.
+- **Against the running dev server** (`diagnostics: true` in vite.config.ts; dev-only, no-op in builds). Requires an open page connected to the dev server (e.g. via a browser tool):
+  - `GET /__solid/diagnostics` — status and connected client count
+  - `POST /__solid/diagnostics` with JSON `{"method":"begin"}` then `{"method":"end"}` — capture a session into an artifact
+  - `{"method":"whyDidRun","params":{"name":"<scope name>"}}` — recorded re-runs of one named scope in the open session
+  - `{"method":"costs"}` — running cost tables for the open session
+
+Name your signals/memos/effects (the `{ name: "..." }` option) — attribution reports scopes by name.

--- a/solid-v2/with-tailwindcss/package.json
+++ b/solid-v2/with-tailwindcss/package.json
@@ -13,8 +13,9 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@solidjs/testing-library": "1.0.0-beta.2",
-    "@solidjs/vite-plugin": "^3.0.0-next.33",
+    "@solidjs/diagnostics": "^2.0.0-rc.3",
+    "@solidjs/testing-library": "^1.0.0-beta.2",
+    "@solidjs/vite-plugin": "^3.0.0-next.34",
     "@tailwindcss/vite": "^4.1.13",
     "@testing-library/jest-dom": "^6.6.3",
     "eslint-plugin-solid": "~0.16.0",
@@ -28,8 +29,8 @@
   },
   "dependencies": {
     "@solidjs/meta": "^1.0.0-next.2",
-    "@solidjs/router": "^2.0.0-next.16",
-    "@solidjs/web": "^2.0.0-rc.2",
-    "solid-js": "^2.0.0-rc.2"
+    "@solidjs/router": "^2.0.0-next.17",
+    "@solidjs/web": "^2.0.0-rc.3",
+    "solid-js": "^2.0.0-rc.3"
   }
 }

--- a/solid-v2/with-tailwindcss/pnpm-lock.yaml
+++ b/solid-v2/with-tailwindcss/pnpm-lock.yaml
@@ -10,23 +10,26 @@ importers:
     dependencies:
       '@solidjs/meta':
         specifier: ^1.0.0-next.2
-        version: 1.0.0-next.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)
+        version: 1.0.0-next.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/router':
-        specifier: ^2.0.0-next.16
-        version: 2.0.0-next.16(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)
+        specifier: ^2.0.0-next.17
+        version: 2.0.0-next.17(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/web':
-        specifier: ^2.0.0-rc.2
-        version: 2.0.0-rc.2(solid-js@2.0.0-rc.2)
+        specifier: ^2.0.0-rc.3
+        version: 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       solid-js:
-        specifier: ^2.0.0-rc.2
-        version: 2.0.0-rc.2
+        specifier: ^2.0.0-rc.3
+        version: 2.0.0-rc.3
     devDependencies:
+      '@solidjs/diagnostics':
+        specifier: ^2.0.0-rc.3
+        version: 2.0.0-rc.3(vitest@4.1.10(jsdom@25.0.1)(vite@8.2.1(jiti@2.7.0)))
       '@solidjs/testing-library':
-        specifier: 1.0.0-beta.2
-        version: 1.0.0-beta.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)
+        specifier: ^1.0.0-beta.2
+        version: 1.0.0-beta.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/vite-plugin':
-        specifier: ^3.0.0-next.33
-        version: 3.0.0-next.33(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.2)(vite@8.2.1(jiti@2.7.0))
+        specifier: ^3.0.0-next.34
+        version: 3.0.0-next.34(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.3)(vite@8.2.1(jiti@2.7.0))
       '@tailwindcss/vite':
         specifier: ^4.1.13
         version: 4.3.3(vite@8.2.1(jiti@2.7.0))
@@ -183,59 +186,23 @@ packages:
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.42':
-    resolution: {integrity: sha512-ol24x9RW8loPyOTzC/mQzh/zAsrsPxyTG4WRxxRlwzNK2uBWIBftWN5IwmSV51zDQa7JcT6sE6kkXFCLUvsYIQ==}
-    peerDependencies:
-      '@babel/core': ^7.20.12
-
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
-    resolution: {integrity: sha512-7l575p7EQu16lssfbtgspSBWBSK5+car5NP4VYD/iJiK+Qd2VcMQMwaOjgA1xCs/P0S0l9EFY9BHGIJcHQTL+w==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
-    resolution: {integrity: sha512-NRbfI3HhBPsSrSQvSUfQXvPXfEKjUQKnbBVCDvcu7ISBPMQd+0yH9M+Qmlf7kVq4Ci9qa1HL5EA2jD22d2v73A==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
-    resolution: {integrity: sha512-/Gfa8j/YHBKK1i8b2VQw3ewBlA6qlEZSAn+b7g3z1g18WydPUI/TZWISKpgNxAtyl9m9MvwgbWA1HcHVkf4zyg==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
-    resolution: {integrity: sha512-gV4J4Sr1+6Awnkl5npREqPvxcDfgw4PGguTdFnsHVN9cxAFet3ujcCbWsAJ+QMBUQ8OT/LG6d4oJLlAkQ0D1fA==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
-    resolution: {integrity: sha512-YrzoB/YZtrmnGXhz3sxs7VeuAXT0JRc6NguNX8iDNt5p5fQ0QX+HR75GYMsxY9FceSVTHObrm3fA/8KGYo5z6Q==}
-    engines: {node: '>=14.0.0'}
-
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
-    resolution: {integrity: sha512-BNQEgny4zyjceZqCaRJDCrQ2oy6z7oXruAE/du2uJB7qLz/z24ISJVUKeKHPb5mRzHuSiTlDcK7pDzE7jPPXjg==}
-    cpu: [x64]
-    os: [win32]
-
-  '@dom-expressions/compiler@0.50.0-next.44':
-    resolution: {integrity: sha512-CBj0k+LcpCk8+nJGY7uvqxLC5NLxXTx9l0fuMZBBkBAOgVf5/IlMyMSpaYE5H5AkFiajR05NYvNR07R6e0KZ3w==}
-
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
-  '@emnapi/core@1.11.2':
-    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+  '@emnapi/core@1.11.3':
+    resolution: {integrity: sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==}
 
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
-  '@emnapi/runtime@1.11.2':
-    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@emnapi/wasi-threads@1.2.3':
+    resolution: {integrity: sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==}
 
   '@eslint-community/eslint-utils@4.10.1':
     resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
@@ -670,20 +637,67 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@solidjs/babel-plugin@2.0.0-rc.3':
+    resolution: {integrity: sha512-VLqCvvMukrACeMuF3uPTyx9l+qCQ9H1G25vOl7FXAdu9rMrLEKZ2IEoiUMczn0mhXAVeplJVEvr7+gSy5m4omA==}
+    peerDependencies:
+      '@babel/core': ^7.20.12
+
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.3':
+    resolution: {integrity: sha512-P9Ngf6KUwM+KGAAUZ40776+1utbk/n3+F+WhyyYm+rUpjO0um9EqBJLvafqEp6kGgSHQ2j5UhioqcuqhesMLbQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.3':
+    resolution: {integrity: sha512-PozalaeiMJxPF7H5ePpqOGM8F9H07sFsSGxyHHZiUn8c4HIBlsacNpc06gUcoJ1xzm7AvayNCV9BJOw2hQYaYg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3':
+    resolution: {integrity: sha512-riY4uwHCqq5vfrlYY7AK8xy/r/Wd98NCnbGqFsDb7bL7TNw398VuA5+hoK4cnsQJe4dqvI2zXFEdmP5xSNAFSQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3':
+    resolution: {integrity: sha512-y2GlcmfIqtWBrxOnvgLsGZvdH2tVK/9JzcFTUzWo5kjoiEy+VCV3NSNcBZrMbLJ7ozIDTiuWePZd/G5LphYdmA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3':
+    resolution: {integrity: sha512-mx7LnrAwKaXd9ZiaAwZeBlMjdWNdmR73F+3I1iOxSpH9Lh2Kyx9IIVff0a1AnwUy17tdDxXMbWxoI/ctYfZsdw==}
+    engines: {node: '>=14.0.0'}
+
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3':
+    resolution: {integrity: sha512-7MQDvdSI42/+lSac6L6WVgCYkUezzliLRoCjo7ultpN2hHy3XgohxvrWfE005OQEMg2pamzzFmfeIl8FUi2JRA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@solidjs/compiler@2.0.0-rc.3':
+    resolution: {integrity: sha512-gu2AnJwkrJfk3SBKGRxEUGuP/SZpwUGzHQS5zt56eNG4GFlEMyurahVRSLMWWBhtC1On7wH5SmLxybH2yDCqAg==}
+
+  '@solidjs/diagnostics@2.0.0-rc.3':
+    resolution: {integrity: sha512-fPb20MXqN7LpT02+kxfMBhY3reCKeh7vB++g9Su1EJZ6Ie0PeydyU/CnkUNa9gwLCMKoZG1x0pfAMb9yLGowtw==}
+    peerDependencies:
+      vitest: '>=2.0.0'
+    peerDependenciesMeta:
+      vitest:
+        optional: true
+
   '@solidjs/meta@1.0.0-next.2':
     resolution: {integrity: sha512-4aqPczFqDdep4JTAUXfh4nyfq7InbTgimd7NuN6ZWWE29UPv0uR5dyr53yFcf2YgVXjFdX+JGhXtsE0njGL+fA==}
     peerDependencies:
       '@solidjs/web': ^2.0.0-rc.0
       solid-js: ^2.0.0-rc.0
 
-  '@solidjs/router@2.0.0-next.16':
-    resolution: {integrity: sha512-sYaq5h4ISdDVZKhA1R0X4NHFg4Kao7HpK3QRfbFcE25/x2PFl4VxlHLZIoBUfv3T3L9g4GVTD376pvArwgGlDA==}
+  '@solidjs/router@2.0.0-next.17':
+    resolution: {integrity: sha512-LchYm3IZ3Y7vGPh/Jx6X8UjpBirQrz9ZoRQkgRpdz8A9C7eTiRXY326pJDcoYDXn7FzYtFpRCwsfBMxRDsFo6A==}
     peerDependencies:
-      '@solidjs/web': ^2.0.0-rc.0
-      solid-js: ^2.0.0-rc.0
+      '@solidjs/web': ^2.0.0-rc.1
+      solid-js: ^2.0.0-rc.1
 
-  '@solidjs/signals@2.0.0-rc.2':
-    resolution: {integrity: sha512-nJyXdBZJaYGqtDuQt8csE9LY9oNZV2fZfPRmJHQT9QjQEuHKQ1OaZScZ8YFaeATrnavzys4Ws95LnUdv8pCidQ==}
+  '@solidjs/signals@2.0.0-rc.3':
+    resolution: {integrity: sha512-/yPhTf3xS1FRR4MX8kTYCd4MjsFxzwkO+KyOTfbu35lTEiaJ4Fxy+JL91XonDzt31GV1mYaZ9CGD2TQIzvXuNA==}
 
   '@solidjs/testing-library@1.0.0-beta.2':
     resolution: {integrity: sha512-TLhQ5IUT/fdDfqa4X2rkQWB28Y+zEwi6mK/TVTeiQlEHG63eK2jfgwNYf2NtQoPh2c3ihLilsCzxABiSTP3JoQ==}
@@ -692,8 +706,8 @@ packages:
       '@solidjs/web': '>=2.0.0'
       solid-js: '>=2.0.0'
 
-  '@solidjs/vite-plugin@3.0.0-next.33':
-    resolution: {integrity: sha512-8c6twAU/ko9TUEr3koPnWQ1CzET+muZPJFaxBSLYv0M+WRgtmbjlHl9GxTSfm5dd23JDwGhBcv3gdxr2slV/wg==}
+  '@solidjs/vite-plugin@3.0.0-next.34':
+    resolution: {integrity: sha512-uDxBcBjbcS6k509TXTsNw4PjubT59eInzLAny43N5Ieoa4jROCaWV+EwxedPqtCF7nsHoKGgwC+ysu6w105G0A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@solidjs/start-devtools': ^1.0.0-next.2
@@ -707,10 +721,10 @@ packages:
       '@testing-library/jest-dom':
         optional: true
 
-  '@solidjs/web@2.0.0-rc.2':
-    resolution: {integrity: sha512-JazuW9NCI+kcpZXRq9J/DAGPmMd0pEWr3kuXFmPZV9tOviiTOHDXOf56pjbUFVDZd+120AKoe/ULmYdSDpJmsA==}
+  '@solidjs/web@2.0.0-rc.3':
+    resolution: {integrity: sha512-5ckKgOjem1pN5ADycOk6TjHmTtjbbN2fukqxo6RW3Oe3H7z0gaXWAdt8dLISto5/O4Nn8VxprFXFWpfy31+DUg==}
     peerDependencies:
-      solid-js: ^2.0.0-rc.2
+      solid-js: ^2.0.0-rc.3
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -964,21 +978,12 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  babel-preset-solid@2.0.0-rc.0:
-    resolution: {integrity: sha512-Ap2/QQY3pICj+Q0VM/RnIOpZo7e6icZnUA0oBJuhqzoCrljqMNo3eFb2OeEa4pUQeFREJOlex4Bt1ggwrcgC8w==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-rc.0
-    peerDependenciesMeta:
-      solid-js:
-        optional: true
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  baseline-browser-mapping@2.11.13:
-    resolution: {integrity: sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==}
+  baseline-browser-mapping@2.11.19:
+    resolution: {integrity: sha512-Grytf1xOxOEMTGRwx6rLGKkTabd4vMg3VrKdj/7joCmV0qgh4QwMMO6xh34YEXQqirAuUdgQGa5orJQQ+69RBw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -999,8 +1004,8 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
-  caniuse-lite@1.0.30001809:
-    resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
+  caniuse-lite@1.0.30001810:
+    resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -1068,8 +1073,8 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  electron-to-chromium@1.5.405:
-    resolution: {integrity: sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==}
+  electron-to-chromium@1.5.415:
+    resolution: {integrity: sha512-958V+Kbhtgz+SxXeEVKBjrlKRBIDAYvUJfwhjxMZ5S6ut9jAl7l9ZKBkBrvjyjZE36PabLUo2L8kEeV5O4vgJg==}
 
   enhanced-resolve@5.24.5:
     resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
@@ -1734,8 +1739,8 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
-  solid-js@2.0.0-rc.2:
-    resolution: {integrity: sha512-1C++20cho5f+omXbX6MIl+VrBZ+by6QkWpCtpbVmmUR80EGgH4irqV0UdP88GAYHx1U+FzpCcHxIGoA9raCyQA==}
+  solid-js@2.0.0-rc.3:
+    resolution: {integrity: sha512-pmW6bRoTvfp/rN4jN7JmLvSaoIpFt7wm0Hi3j508S/smuJqUbRg3dQEjOPTkAwHW+McYnXrMG7cJ4AMNpLevtQ==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2131,56 +2136,15 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.42(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
-      '@babel/types': 7.29.8
-      html-entities: 2.3.3
-      parse5: 7.3.0
-      validate-html-nesting: 1.2.4
-
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
-    dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
-      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
-    optional: true
-
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler@0.50.0-next.44':
-    optionalDependencies:
-      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.44
-      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.44
-      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.44
-      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.44
-      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.44
-      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.44
-
   '@emnapi/core@1.11.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/core@1.11.2':
+  '@emnapi/core@1.11.3':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.2
+      '@emnapi/wasi-threads': 1.2.3
       tslib: 2.8.1
     optional: true
 
@@ -2189,12 +2153,17 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.11.2':
+  '@emnapi/runtime@1.11.3':
     dependencies:
       tslib: 2.8.1
     optional: true
 
   '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2271,10 +2240,10 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -2459,34 +2428,81 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@solidjs/meta@1.0.0-next.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)':
+  '@solidjs/babel-plugin@2.0.0-rc.3(@babel/core@7.29.7)':
     dependencies:
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/types': 7.29.8
+      html-entities: 2.3.3
+      parse5: 7.3.0
+      validate-html-nesting: 1.2.4
 
-  '@solidjs/router@2.0.0-next.16(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)':
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3':
     dependencies:
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+    optional: true
 
-  '@solidjs/signals@2.0.0-rc.2': {}
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3':
+    optional: true
 
-  '@solidjs/testing-library@1.0.0-beta.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)':
+  '@solidjs/compiler@2.0.0-rc.3':
+    optionalDependencies:
+      '@solidjs/compiler-darwin-arm64': 2.0.0-rc.3
+      '@solidjs/compiler-darwin-x64': 2.0.0-rc.3
+      '@solidjs/compiler-linux-arm64-gnu': 2.0.0-rc.3
+      '@solidjs/compiler-linux-x64-gnu': 2.0.0-rc.3
+      '@solidjs/compiler-wasm32-wasi': 2.0.0-rc.3
+      '@solidjs/compiler-win32-x64-msvc': 2.0.0-rc.3
+
+  '@solidjs/diagnostics@2.0.0-rc.3(vitest@4.1.10(jsdom@25.0.1)(vite@8.2.1(jiti@2.7.0)))':
     dependencies:
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
+      '@solidjs/signals': 2.0.0-rc.3
+    optionalDependencies:
+      vitest: 4.1.10(jsdom@25.0.1)(vite@8.2.1(jiti@2.7.0))
+
+  '@solidjs/meta@1.0.0-next.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
+    dependencies:
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
+
+  '@solidjs/router@2.0.0-next.17(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
+    dependencies:
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
+
+  '@solidjs/signals@2.0.0-rc.3': {}
+
+  '@solidjs/testing-library@1.0.0-beta.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
+    dependencies:
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@testing-library/dom': 10.4.1
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
 
-  '@solidjs/vite-plugin@3.0.0-next.33(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.2)(vite@8.2.1(jiti@2.7.0))':
+  '@solidjs/vite-plugin@3.0.0-next.34(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.3)(vite@8.2.1(jiti@2.7.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/core': 7.29.7
-      '@dom-expressions/compiler': 0.50.0-next.44
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
+      '@solidjs/babel-plugin': 2.0.0-rc.3(@babel/core@7.29.7)
+      '@solidjs/compiler': 2.0.0-rc.3
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-rc.0(@babel/core@7.29.7)(solid-js@2.0.0-rc.2)
       merge-anything: 5.1.7
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
       vite: 8.2.1(jiti@2.7.0)
       vitefu: 1.1.3(vite@8.2.1(jiti@2.7.0))
     optionalDependencies:
@@ -2494,11 +2510,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2)':
+  '@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3)':
     dependencies:
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -2759,16 +2775,9 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  babel-preset-solid@2.0.0-rc.0(@babel/core@7.29.7)(solid-js@2.0.0-rc.2):
-    dependencies:
-      '@babel/core': 7.29.7
-      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.42(@babel/core@7.29.7)
-    optionalDependencies:
-      solid-js: 2.0.0-rc.2
-
   balanced-match@4.0.4: {}
 
-  baseline-browser-mapping@2.11.13: {}
+  baseline-browser-mapping@2.11.19: {}
 
   brace-expansion@5.0.9:
     dependencies:
@@ -2780,9 +2789,9 @@ snapshots:
 
   browserslist@4.28.8:
     dependencies:
-      baseline-browser-mapping: 2.11.13
-      caniuse-lite: 1.0.30001809
-      electron-to-chromium: 1.5.405
+      baseline-browser-mapping: 2.11.19
+      caniuse-lite: 1.0.30001810
+      electron-to-chromium: 1.5.415
       node-releases: 2.0.53
       update-browserslist-db: 1.3.1(browserslist@4.28.8)
 
@@ -2791,7 +2800,7 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
-  caniuse-lite@1.0.30001809: {}
+  caniuse-lite@1.0.30001810: {}
 
   chai@6.2.2: {}
 
@@ -2845,7 +2854,7 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  electron-to-chromium@1.5.405: {}
+  electron-to-chromium@1.5.415: {}
 
   enhanced-resolve@5.24.5:
     dependencies:
@@ -3491,9 +3500,9 @@ snapshots:
 
   siginfo@2.0.0: {}
 
-  solid-js@2.0.0-rc.2:
+  solid-js@2.0.0-rc.3:
     dependencies:
-      '@solidjs/signals': 2.0.0-rc.2
+      '@solidjs/signals': 2.0.0-rc.3
       csstype: 3.2.3
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)

--- a/solid-v2/with-tailwindcss/vite.config.ts
+++ b/solid-v2/with-tailwindcss/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   plugins: [
     // `extensions` makes @solidjs/vite-plugin also compile the `?pick=` route
     // modules the fileRoutes plugin emits (their ids end in a query string).
-    solid({ start: true, extensions: ['.jsx', '.tsx'] }), // add `ssr: true` for streaming SSR
+    solid({ start: true, extensions: ['.jsx', '.tsx'], diagnostics: true }), // add `ssr: true` for streaming SSR
     fileRoutes({ types: true }),
     // Scans source files for class names and generates their CSS into the
     // stylesheet that imports tailwindcss (src/App.css).

--- a/solid-v2/with-tanstack-router/AGENTS.md
+++ b/solid-v2/with-tanstack-router/AGENTS.md
@@ -1,0 +1,23 @@
+# Agent Guide
+
+This is a SolidJS 2.x project. Solid is not React: components run once (there is no re-render), reactivity is fine-grained through signals, and effects/memos have Solid-specific semantics. Do not port React patterns.
+
+## Versioned skills (in node_modules — read on demand)
+
+The installed packages ship agent skills that match their exact installed versions:
+
+- `node_modules/solid-js/skills/reactivity-diagnostics/SKILL.md` — repair guide mapping every dev-mode diagnostic code (e.g. `REACTIVE_WRITE_IN_OWNED_SCOPE`, `STRICT_READ_UNTRACKED`) to its prescribed fix. Read it whenever a Solid diagnostic code appears in test output or the browser console.
+- `node_modules/@solidjs/diagnostics/skills/agent-loops/SKILL.md` — how to capture reactive evidence (which scopes re-ran and why, wasted recomputes, cost tables) and assert budgets, in tests and against live pages.
+
+## Reactive diagnostics — capture evidence instead of guessing
+
+Use these whenever you are debugging reactivity (something doesn't update, updates too often, or is slow) or verifying a change didn't regress update granularity:
+
+- **In tests:** `captureArtifact()` from `@solidjs/diagnostics` wraps a scenario and returns a serializable artifact of diagnostics + rerun attribution; matchers from `@solidjs/diagnostics/vitest` (`toHaveNoDiagnostics`, `toStayWithinRerunBudget`, `toHaveNoWaste`, …) assert on it. No browser needed.
+- **Against the running dev server** (`diagnostics: true` in vite.config.ts; dev-only, no-op in builds). Requires an open page connected to the dev server (e.g. via a browser tool):
+  - `GET /__solid/diagnostics` — status and connected client count
+  - `POST /__solid/diagnostics` with JSON `{"method":"begin"}` then `{"method":"end"}` — capture a session into an artifact
+  - `{"method":"whyDidRun","params":{"name":"<scope name>"}}` — recorded re-runs of one named scope in the open session
+  - `{"method":"costs"}` — running cost tables for the open session
+
+Name your signals/memos/effects (the `{ name: "..." }` option) — attribution reports scopes by name.

--- a/solid-v2/with-tanstack-router/package.json
+++ b/solid-v2/with-tanstack-router/package.json
@@ -13,8 +13,9 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@solidjs/testing-library": "1.0.0-beta.2",
-    "@solidjs/vite-plugin": "^3.0.0-next.33",
+    "@solidjs/diagnostics": "^2.0.0-rc.3",
+    "@solidjs/testing-library": "^1.0.0-beta.2",
+    "@solidjs/vite-plugin": "^3.0.0-next.34",
     "@tanstack/router-plugin": "1.168.27",
     "@testing-library/jest-dom": "^6.6.3",
     "eslint-plugin-solid": "~0.16.0",
@@ -25,8 +26,8 @@
     "vitest": "^4.0.0"
   },
   "dependencies": {
-    "@solidjs/web": "^2.0.0-rc.2",
+    "@solidjs/web": "^2.0.0-rc.3",
     "@tanstack/solid-router": "^2.0.0-rc.1",
-    "solid-js": "^2.0.0-rc.2"
+    "solid-js": "^2.0.0-rc.3"
   }
 }

--- a/solid-v2/with-tanstack-router/pnpm-lock.yaml
+++ b/solid-v2/with-tanstack-router/pnpm-lock.yaml
@@ -9,21 +9,24 @@ importers:
   .:
     dependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-rc.2
-        version: 2.0.0-rc.2(solid-js@2.0.0-rc.2)
+        specifier: ^2.0.0-rc.3
+        version: 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@tanstack/solid-router':
         specifier: ^2.0.0-rc.1
-        version: 2.0.0-rc.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)
+        version: 2.0.0-rc.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       solid-js:
-        specifier: ^2.0.0-rc.2
-        version: 2.0.0-rc.2
+        specifier: ^2.0.0-rc.3
+        version: 2.0.0-rc.3
     devDependencies:
+      '@solidjs/diagnostics':
+        specifier: ^2.0.0-rc.3
+        version: 2.0.0-rc.3(vitest@4.1.10(jsdom@25.0.1)(vite@8.2.1(jiti@2.7.0)))
       '@solidjs/testing-library':
-        specifier: 1.0.0-beta.2
-        version: 1.0.0-beta.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)
+        specifier: ^1.0.0-beta.2
+        version: 1.0.0-beta.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/vite-plugin':
-        specifier: ^3.0.0-next.33
-        version: 3.0.0-next.33(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.2)(vite@8.2.1(jiti@2.7.0))
+        specifier: ^3.0.0-next.34
+        version: 3.0.0-next.34(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.3)(vite@8.2.1(jiti@2.7.0))
       '@tanstack/router-plugin':
         specifier: 1.168.27
         version: 1.168.27(rolldown@1.2.4)(vite@8.2.1(jiti@2.7.0))
@@ -174,53 +177,14 @@ packages:
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.42':
-    resolution: {integrity: sha512-ol24x9RW8loPyOTzC/mQzh/zAsrsPxyTG4WRxxRlwzNK2uBWIBftWN5IwmSV51zDQa7JcT6sE6kkXFCLUvsYIQ==}
-    peerDependencies:
-      '@babel/core': ^7.20.12
+  '@emnapi/core@1.11.3':
+    resolution: {integrity: sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==}
 
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
-    resolution: {integrity: sha512-7l575p7EQu16lssfbtgspSBWBSK5+car5NP4VYD/iJiK+Qd2VcMQMwaOjgA1xCs/P0S0l9EFY9BHGIJcHQTL+w==}
-    cpu: [arm64]
-    os: [darwin]
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
-    resolution: {integrity: sha512-NRbfI3HhBPsSrSQvSUfQXvPXfEKjUQKnbBVCDvcu7ISBPMQd+0yH9M+Qmlf7kVq4Ci9qa1HL5EA2jD22d2v73A==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
-    resolution: {integrity: sha512-/Gfa8j/YHBKK1i8b2VQw3ewBlA6qlEZSAn+b7g3z1g18WydPUI/TZWISKpgNxAtyl9m9MvwgbWA1HcHVkf4zyg==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
-    resolution: {integrity: sha512-gV4J4Sr1+6Awnkl5npREqPvxcDfgw4PGguTdFnsHVN9cxAFet3ujcCbWsAJ+QMBUQ8OT/LG6d4oJLlAkQ0D1fA==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
-    resolution: {integrity: sha512-YrzoB/YZtrmnGXhz3sxs7VeuAXT0JRc6NguNX8iDNt5p5fQ0QX+HR75GYMsxY9FceSVTHObrm3fA/8KGYo5z6Q==}
-    engines: {node: '>=14.0.0'}
-
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
-    resolution: {integrity: sha512-BNQEgny4zyjceZqCaRJDCrQ2oy6z7oXruAE/du2uJB7qLz/z24ISJVUKeKHPb5mRzHuSiTlDcK7pDzE7jPPXjg==}
-    cpu: [x64]
-    os: [win32]
-
-  '@dom-expressions/compiler@0.50.0-next.44':
-    resolution: {integrity: sha512-CBj0k+LcpCk8+nJGY7uvqxLC5NLxXTx9l0fuMZBBkBAOgVf5/IlMyMSpaYE5H5AkFiajR05NYvNR07R6e0KZ3w==}
-
-  '@emnapi/core@1.11.2':
-    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
-
-  '@emnapi/runtime@1.11.2':
-    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
-
-  '@emnapi/wasi-threads@1.2.2':
-    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+  '@emnapi/wasi-threads@1.2.3':
+    resolution: {integrity: sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==}
 
   '@eslint-community/eslint-utils@4.10.1':
     resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
@@ -586,13 +550,60 @@ packages:
     peerDependencies:
       solid-js: ^1.6.12
 
+  '@solidjs/babel-plugin@2.0.0-rc.3':
+    resolution: {integrity: sha512-VLqCvvMukrACeMuF3uPTyx9l+qCQ9H1G25vOl7FXAdu9rMrLEKZ2IEoiUMczn0mhXAVeplJVEvr7+gSy5m4omA==}
+    peerDependencies:
+      '@babel/core': ^7.20.12
+
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.3':
+    resolution: {integrity: sha512-P9Ngf6KUwM+KGAAUZ40776+1utbk/n3+F+WhyyYm+rUpjO0um9EqBJLvafqEp6kGgSHQ2j5UhioqcuqhesMLbQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.3':
+    resolution: {integrity: sha512-PozalaeiMJxPF7H5ePpqOGM8F9H07sFsSGxyHHZiUn8c4HIBlsacNpc06gUcoJ1xzm7AvayNCV9BJOw2hQYaYg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3':
+    resolution: {integrity: sha512-riY4uwHCqq5vfrlYY7AK8xy/r/Wd98NCnbGqFsDb7bL7TNw398VuA5+hoK4cnsQJe4dqvI2zXFEdmP5xSNAFSQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3':
+    resolution: {integrity: sha512-y2GlcmfIqtWBrxOnvgLsGZvdH2tVK/9JzcFTUzWo5kjoiEy+VCV3NSNcBZrMbLJ7ozIDTiuWePZd/G5LphYdmA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3':
+    resolution: {integrity: sha512-mx7LnrAwKaXd9ZiaAwZeBlMjdWNdmR73F+3I1iOxSpH9Lh2Kyx9IIVff0a1AnwUy17tdDxXMbWxoI/ctYfZsdw==}
+    engines: {node: '>=14.0.0'}
+
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3':
+    resolution: {integrity: sha512-7MQDvdSI42/+lSac6L6WVgCYkUezzliLRoCjo7ultpN2hHy3XgohxvrWfE005OQEMg2pamzzFmfeIl8FUi2JRA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@solidjs/compiler@2.0.0-rc.3':
+    resolution: {integrity: sha512-gu2AnJwkrJfk3SBKGRxEUGuP/SZpwUGzHQS5zt56eNG4GFlEMyurahVRSLMWWBhtC1On7wH5SmLxybH2yDCqAg==}
+
+  '@solidjs/diagnostics@2.0.0-rc.3':
+    resolution: {integrity: sha512-fPb20MXqN7LpT02+kxfMBhY3reCKeh7vB++g9Su1EJZ6Ie0PeydyU/CnkUNa9gwLCMKoZG1x0pfAMb9yLGowtw==}
+    peerDependencies:
+      vitest: '>=2.0.0'
+    peerDependenciesMeta:
+      vitest:
+        optional: true
+
   '@solidjs/meta@0.29.4':
     resolution: {integrity: sha512-zdIWBGpR9zGx1p1bzIPqF5Gs+Ks/BH8R6fWhmUa/dcK1L2rUC8BAcZJzNRYBQv74kScf1TSOs0EY//Vd/I0V8g==}
     peerDependencies:
       solid-js: '>=1.8.4'
 
-  '@solidjs/signals@2.0.0-rc.2':
-    resolution: {integrity: sha512-nJyXdBZJaYGqtDuQt8csE9LY9oNZV2fZfPRmJHQT9QjQEuHKQ1OaZScZ8YFaeATrnavzys4Ws95LnUdv8pCidQ==}
+  '@solidjs/signals@2.0.0-rc.3':
+    resolution: {integrity: sha512-/yPhTf3xS1FRR4MX8kTYCd4MjsFxzwkO+KyOTfbu35lTEiaJ4Fxy+JL91XonDzt31GV1mYaZ9CGD2TQIzvXuNA==}
 
   '@solidjs/testing-library@1.0.0-beta.2':
     resolution: {integrity: sha512-TLhQ5IUT/fdDfqa4X2rkQWB28Y+zEwi6mK/TVTeiQlEHG63eK2jfgwNYf2NtQoPh2c3ihLilsCzxABiSTP3JoQ==}
@@ -601,8 +612,8 @@ packages:
       '@solidjs/web': '>=2.0.0'
       solid-js: '>=2.0.0'
 
-  '@solidjs/vite-plugin@3.0.0-next.33':
-    resolution: {integrity: sha512-8c6twAU/ko9TUEr3koPnWQ1CzET+muZPJFaxBSLYv0M+WRgtmbjlHl9GxTSfm5dd23JDwGhBcv3gdxr2slV/wg==}
+  '@solidjs/vite-plugin@3.0.0-next.34':
+    resolution: {integrity: sha512-uDxBcBjbcS6k509TXTsNw4PjubT59eInzLAny43N5Ieoa4jROCaWV+EwxedPqtCF7nsHoKGgwC+ysu6w105G0A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@solidjs/start-devtools': ^1.0.0-next.2
@@ -616,10 +627,10 @@ packages:
       '@testing-library/jest-dom':
         optional: true
 
-  '@solidjs/web@2.0.0-rc.2':
-    resolution: {integrity: sha512-JazuW9NCI+kcpZXRq9J/DAGPmMd0pEWr3kuXFmPZV9tOviiTOHDXOf56pjbUFVDZd+120AKoe/ULmYdSDpJmsA==}
+  '@solidjs/web@2.0.0-rc.3':
+    resolution: {integrity: sha512-5ckKgOjem1pN5ADycOk6TjHmTtjbbN2fukqxo6RW3Oe3H7z0gaXWAdt8dLISto5/O4Nn8VxprFXFWpfy31+DUg==}
     peerDependencies:
-      solid-js: ^2.0.0-rc.2
+      solid-js: ^2.0.0-rc.3
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -832,21 +843,12 @@ packages:
   babel-dead-code-elimination@1.0.12:
     resolution: {integrity: sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==}
 
-  babel-preset-solid@2.0.0-rc.0:
-    resolution: {integrity: sha512-Ap2/QQY3pICj+Q0VM/RnIOpZo7e6icZnUA0oBJuhqzoCrljqMNo3eFb2OeEa4pUQeFREJOlex4Bt1ggwrcgC8w==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-rc.0
-    peerDependenciesMeta:
-      solid-js:
-        optional: true
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  baseline-browser-mapping@2.11.13:
-    resolution: {integrity: sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==}
+  baseline-browser-mapping@2.11.19:
+    resolution: {integrity: sha512-Grytf1xOxOEMTGRwx6rLGKkTabd4vMg3VrKdj/7joCmV0qgh4QwMMO6xh34YEXQqirAuUdgQGa5orJQQ+69RBw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -863,8 +865,8 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
-  caniuse-lite@1.0.30001809:
-    resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
+  caniuse-lite@1.0.30001810:
+    resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -943,8 +945,8 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  electron-to-chromium@1.5.405:
-    resolution: {integrity: sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==}
+  electron-to-chromium@1.5.415:
+    resolution: {integrity: sha512-958V+Kbhtgz+SxXeEVKBjrlKRBIDAYvUJfwhjxMZ5S6ut9jAl7l9ZKBkBrvjyjZE36PabLUo2L8kEeV5O4vgJg==}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -1495,8 +1497,8 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
-  solid-js@2.0.0-rc.2:
-    resolution: {integrity: sha512-1C++20cho5f+omXbX6MIl+VrBZ+by6QkWpCtpbVmmUR80EGgH4irqV0UdP88GAYHx1U+FzpCcHxIGoA9raCyQA==}
+  solid-js@2.0.0-rc.3:
+    resolution: {integrity: sha512-pmW6bRoTvfp/rN4jN7JmLvSaoIpFt7wm0Hi3j508S/smuJqUbRg3dQEjOPTkAwHW+McYnXrMG7cJ4AMNpLevtQ==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -1920,59 +1922,18 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.42(@babel/core@7.29.7)':
+  '@emnapi/core@1.11.3':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
-      '@babel/types': 7.29.8
-      html-entities: 2.3.3
-      parse5: 7.3.0
-      validate-html-nesting: 1.2.4
-
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
-    dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
-      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
-    optional: true
-
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler@0.50.0-next.44':
-    optionalDependencies:
-      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.44
-      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.44
-      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.44
-      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.44
-      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.44
-      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.44
-
-  '@emnapi/core@1.11.2':
-    dependencies:
-      '@emnapi/wasi-threads': 1.2.2
+      '@emnapi/wasi-threads': 1.2.3
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.11.2':
+  '@emnapi/runtime@1.11.3':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/wasi-threads@1.2.2':
+  '@emnapi/wasi-threads@1.2.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2042,10 +2003,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -2154,127 +2115,174 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@solid-devtools/debugger@0.28.1(solid-js@2.0.0-rc.2)':
+  '@solid-devtools/debugger@0.28.1(solid-js@2.0.0-rc.3)':
     dependencies:
       '@nothing-but/utils': 0.17.0
-      '@solid-devtools/shared': 0.20.0(solid-js@2.0.0-rc.2)
-      '@solid-primitives/bounds': 0.1.7(solid-js@2.0.0-rc.2)
-      '@solid-primitives/event-listener': 2.4.6(solid-js@2.0.0-rc.2)
-      '@solid-primitives/keyboard': 1.3.7(solid-js@2.0.0-rc.2)
-      '@solid-primitives/rootless': 1.5.4(solid-js@2.0.0-rc.2)
-      '@solid-primitives/scheduled': 1.5.3(solid-js@2.0.0-rc.2)
-      '@solid-primitives/static-store': 0.1.4(solid-js@2.0.0-rc.2)
-      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@solid-devtools/shared': 0.20.0(solid-js@2.0.0-rc.3)
+      '@solid-primitives/bounds': 0.1.7(solid-js@2.0.0-rc.3)
+      '@solid-primitives/event-listener': 2.4.6(solid-js@2.0.0-rc.3)
+      '@solid-primitives/keyboard': 1.3.7(solid-js@2.0.0-rc.3)
+      '@solid-primitives/rootless': 1.5.4(solid-js@2.0.0-rc.3)
+      '@solid-primitives/scheduled': 1.5.3(solid-js@2.0.0-rc.3)
+      '@solid-primitives/static-store': 0.1.4(solid-js@2.0.0-rc.3)
+      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
 
-  '@solid-devtools/logger@0.9.11(solid-js@2.0.0-rc.2)':
+  '@solid-devtools/logger@0.9.11(solid-js@2.0.0-rc.3)':
     dependencies:
       '@nothing-but/utils': 0.17.0
-      '@solid-devtools/debugger': 0.28.1(solid-js@2.0.0-rc.2)
-      '@solid-devtools/shared': 0.20.0(solid-js@2.0.0-rc.2)
-      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@solid-devtools/debugger': 0.28.1(solid-js@2.0.0-rc.3)
+      '@solid-devtools/shared': 0.20.0(solid-js@2.0.0-rc.3)
+      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
 
-  '@solid-devtools/shared@0.20.0(solid-js@2.0.0-rc.2)':
+  '@solid-devtools/shared@0.20.0(solid-js@2.0.0-rc.3)':
     dependencies:
       '@nothing-but/utils': 0.17.0
-      '@solid-primitives/event-listener': 2.4.6(solid-js@2.0.0-rc.2)
-      '@solid-primitives/media': 2.3.6(solid-js@2.0.0-rc.2)
-      '@solid-primitives/refs': 1.1.4(solid-js@2.0.0-rc.2)
-      '@solid-primitives/rootless': 1.5.4(solid-js@2.0.0-rc.2)
-      '@solid-primitives/scheduled': 1.5.3(solid-js@2.0.0-rc.2)
-      '@solid-primitives/static-store': 0.1.4(solid-js@2.0.0-rc.2)
-      '@solid-primitives/styles': 0.1.4(solid-js@2.0.0-rc.2)
-      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@solid-primitives/event-listener': 2.4.6(solid-js@2.0.0-rc.3)
+      '@solid-primitives/media': 2.3.6(solid-js@2.0.0-rc.3)
+      '@solid-primitives/refs': 1.1.4(solid-js@2.0.0-rc.3)
+      '@solid-primitives/rootless': 1.5.4(solid-js@2.0.0-rc.3)
+      '@solid-primitives/scheduled': 1.5.3(solid-js@2.0.0-rc.3)
+      '@solid-primitives/static-store': 0.1.4(solid-js@2.0.0-rc.3)
+      '@solid-primitives/styles': 0.1.4(solid-js@2.0.0-rc.3)
+      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
 
-  '@solid-primitives/bounds@0.1.7(solid-js@2.0.0-rc.2)':
+  '@solid-primitives/bounds@0.1.7(solid-js@2.0.0-rc.3)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.6(solid-js@2.0.0-rc.2)
-      '@solid-primitives/resize-observer': 2.2.0(solid-js@2.0.0-rc.2)
-      '@solid-primitives/static-store': 0.1.4(solid-js@2.0.0-rc.2)
-      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@solid-primitives/event-listener': 2.4.6(solid-js@2.0.0-rc.3)
+      '@solid-primitives/resize-observer': 2.2.0(solid-js@2.0.0-rc.3)
+      '@solid-primitives/static-store': 0.1.4(solid-js@2.0.0-rc.3)
+      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
 
-  '@solid-primitives/event-listener@2.4.6(solid-js@2.0.0-rc.2)':
+  '@solid-primitives/event-listener@2.4.6(solid-js@2.0.0-rc.3)':
     dependencies:
-      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
 
-  '@solid-primitives/keyboard@1.3.7(solid-js@2.0.0-rc.2)':
+  '@solid-primitives/keyboard@1.3.7(solid-js@2.0.0-rc.3)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.6(solid-js@2.0.0-rc.2)
-      '@solid-primitives/rootless': 1.5.4(solid-js@2.0.0-rc.2)
-      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@solid-primitives/event-listener': 2.4.6(solid-js@2.0.0-rc.3)
+      '@solid-primitives/rootless': 1.5.4(solid-js@2.0.0-rc.3)
+      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
 
-  '@solid-primitives/media@2.3.6(solid-js@2.0.0-rc.2)':
+  '@solid-primitives/media@2.3.6(solid-js@2.0.0-rc.3)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.6(solid-js@2.0.0-rc.2)
-      '@solid-primitives/rootless': 1.5.4(solid-js@2.0.0-rc.2)
-      '@solid-primitives/static-store': 0.1.4(solid-js@2.0.0-rc.2)
-      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@solid-primitives/event-listener': 2.4.6(solid-js@2.0.0-rc.3)
+      '@solid-primitives/rootless': 1.5.4(solid-js@2.0.0-rc.3)
+      '@solid-primitives/static-store': 0.1.4(solid-js@2.0.0-rc.3)
+      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
 
-  '@solid-primitives/refs@1.1.4(solid-js@2.0.0-rc.2)':
+  '@solid-primitives/refs@1.1.4(solid-js@2.0.0-rc.3)':
     dependencies:
-      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
 
-  '@solid-primitives/resize-observer@2.2.0(solid-js@2.0.0-rc.2)':
+  '@solid-primitives/resize-observer@2.2.0(solid-js@2.0.0-rc.3)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.6(solid-js@2.0.0-rc.2)
-      '@solid-primitives/rootless': 1.5.4(solid-js@2.0.0-rc.2)
-      '@solid-primitives/static-store': 0.1.4(solid-js@2.0.0-rc.2)
-      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@solid-primitives/event-listener': 2.4.6(solid-js@2.0.0-rc.3)
+      '@solid-primitives/rootless': 1.5.4(solid-js@2.0.0-rc.3)
+      '@solid-primitives/static-store': 0.1.4(solid-js@2.0.0-rc.3)
+      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
 
-  '@solid-primitives/rootless@1.5.4(solid-js@2.0.0-rc.2)':
+  '@solid-primitives/rootless@1.5.4(solid-js@2.0.0-rc.3)':
     dependencies:
-      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
 
-  '@solid-primitives/scheduled@1.5.3(solid-js@2.0.0-rc.2)':
+  '@solid-primitives/scheduled@1.5.3(solid-js@2.0.0-rc.3)':
     dependencies:
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
 
-  '@solid-primitives/static-store@0.1.4(solid-js@2.0.0-rc.2)':
+  '@solid-primitives/static-store@0.1.4(solid-js@2.0.0-rc.3)':
     dependencies:
-      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
 
-  '@solid-primitives/styles@0.1.4(solid-js@2.0.0-rc.2)':
+  '@solid-primitives/styles@0.1.4(solid-js@2.0.0-rc.3)':
     dependencies:
-      '@solid-primitives/rootless': 1.5.4(solid-js@2.0.0-rc.2)
-      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@solid-primitives/rootless': 1.5.4(solid-js@2.0.0-rc.3)
+      '@solid-primitives/utils': 6.4.1(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
 
-  '@solid-primitives/utils@6.4.1(solid-js@2.0.0-rc.2)':
+  '@solid-primitives/utils@6.4.1(solid-js@2.0.0-rc.3)':
     dependencies:
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
 
-  '@solidjs/meta@0.29.4(solid-js@2.0.0-rc.2)':
+  '@solidjs/babel-plugin@2.0.0-rc.3(@babel/core@7.29.7)':
     dependencies:
-      solid-js: 2.0.0-rc.2
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/types': 7.29.8
+      html-entities: 2.3.3
+      parse5: 7.3.0
+      validate-html-nesting: 1.2.4
 
-  '@solidjs/signals@2.0.0-rc.2': {}
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.3':
+    optional: true
 
-  '@solidjs/testing-library@1.0.0-beta.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)':
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3':
     dependencies:
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+    optional: true
+
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler@2.0.0-rc.3':
+    optionalDependencies:
+      '@solidjs/compiler-darwin-arm64': 2.0.0-rc.3
+      '@solidjs/compiler-darwin-x64': 2.0.0-rc.3
+      '@solidjs/compiler-linux-arm64-gnu': 2.0.0-rc.3
+      '@solidjs/compiler-linux-x64-gnu': 2.0.0-rc.3
+      '@solidjs/compiler-wasm32-wasi': 2.0.0-rc.3
+      '@solidjs/compiler-win32-x64-msvc': 2.0.0-rc.3
+
+  '@solidjs/diagnostics@2.0.0-rc.3(vitest@4.1.10(jsdom@25.0.1)(vite@8.2.1(jiti@2.7.0)))':
+    dependencies:
+      '@solidjs/signals': 2.0.0-rc.3
+    optionalDependencies:
+      vitest: 4.1.10(jsdom@25.0.1)(vite@8.2.1(jiti@2.7.0))
+
+  '@solidjs/meta@0.29.4(solid-js@2.0.0-rc.3)':
+    dependencies:
+      solid-js: 2.0.0-rc.3
+
+  '@solidjs/signals@2.0.0-rc.3': {}
+
+  '@solidjs/testing-library@1.0.0-beta.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
+    dependencies:
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@testing-library/dom': 10.4.1
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
 
-  '@solidjs/vite-plugin@3.0.0-next.33(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.2)(vite@8.2.1(jiti@2.7.0))':
+  '@solidjs/vite-plugin@3.0.0-next.34(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.3)(vite@8.2.1(jiti@2.7.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/core': 7.29.7
-      '@dom-expressions/compiler': 0.50.0-next.44
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
+      '@solidjs/babel-plugin': 2.0.0-rc.3(@babel/core@7.29.7)
+      '@solidjs/compiler': 2.0.0-rc.3
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-rc.0(@babel/core@7.29.7)(solid-js@2.0.0-rc.2)
       merge-anything: 5.1.7
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
       vite: 8.2.1(jiti@2.7.0)
       vitefu: 1.1.3(vite@8.2.1(jiti@2.7.0))
     optionalDependencies:
@@ -2282,11 +2290,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2)':
+  '@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3)':
     dependencies:
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -2355,16 +2363,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/solid-router@2.0.0-rc.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)':
+  '@tanstack/solid-router@2.0.0-rc.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
     dependencies:
-      '@solid-devtools/logger': 0.9.11(solid-js@2.0.0-rc.2)
-      '@solid-primitives/refs': 1.1.4(solid-js@2.0.0-rc.2)
-      '@solidjs/meta': 0.29.4(solid-js@2.0.0-rc.2)
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
+      '@solid-devtools/logger': 0.9.11(solid-js@2.0.0-rc.3)
+      '@solid-primitives/refs': 1.1.4(solid-js@2.0.0-rc.3)
+      '@solidjs/meta': 0.29.4(solid-js@2.0.0-rc.3)
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@tanstack/history': 1.162.1
       '@tanstack/router-core': 1.171.22
       isbot: 5.2.1
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
 
   '@tanstack/virtual-file-routes@1.162.0': {}
 
@@ -2562,16 +2570,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-preset-solid@2.0.0-rc.0(@babel/core@7.29.7)(solid-js@2.0.0-rc.2):
-    dependencies:
-      '@babel/core': 7.29.7
-      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.42(@babel/core@7.29.7)
-    optionalDependencies:
-      solid-js: 2.0.0-rc.2
-
   balanced-match@4.0.4: {}
 
-  baseline-browser-mapping@2.11.13: {}
+  baseline-browser-mapping@2.11.19: {}
 
   brace-expansion@5.0.9:
     dependencies:
@@ -2579,9 +2580,9 @@ snapshots:
 
   browserslist@4.28.8:
     dependencies:
-      baseline-browser-mapping: 2.11.13
-      caniuse-lite: 1.0.30001809
-      electron-to-chromium: 1.5.405
+      baseline-browser-mapping: 2.11.19
+      caniuse-lite: 1.0.30001810
+      electron-to-chromium: 1.5.415
       node-releases: 2.0.53
       update-browserslist-db: 1.3.1(browserslist@4.28.8)
 
@@ -2590,7 +2591,7 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
-  caniuse-lite@1.0.30001809: {}
+  caniuse-lite@1.0.30001810: {}
 
   chai@6.2.2: {}
 
@@ -2652,7 +2653,7 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  electron-to-chromium@1.5.405: {}
+  electron-to-chromium@1.5.415: {}
 
   entities@6.0.1: {}
 
@@ -3173,9 +3174,9 @@ snapshots:
 
   siginfo@2.0.0: {}
 
-  solid-js@2.0.0-rc.2:
+  solid-js@2.0.0-rc.3:
     dependencies:
-      '@solidjs/signals': 2.0.0-rc.2
+      '@solidjs/signals': 2.0.0-rc.3
       csstype: 3.2.3
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)

--- a/solid-v2/with-tanstack-router/vite.config.ts
+++ b/solid-v2/with-tanstack-router/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     // Client mode only for now: TanStack's SSR needs per-request router
     // wiring (router.load() + dehydration) that the generated streaming
     // entry doesn't perform — see the README's SSR note.
-    solid({ start: true }),
+    solid({ start: true, diagnostics: true }),
   ],
   server: {
     port: 3000,

--- a/solid-v2/with-unocss/AGENTS.md
+++ b/solid-v2/with-unocss/AGENTS.md
@@ -1,0 +1,23 @@
+# Agent Guide
+
+This is a SolidJS 2.x project. Solid is not React: components run once (there is no re-render), reactivity is fine-grained through signals, and effects/memos have Solid-specific semantics. Do not port React patterns.
+
+## Versioned skills (in node_modules — read on demand)
+
+The installed packages ship agent skills that match their exact installed versions:
+
+- `node_modules/solid-js/skills/reactivity-diagnostics/SKILL.md` — repair guide mapping every dev-mode diagnostic code (e.g. `REACTIVE_WRITE_IN_OWNED_SCOPE`, `STRICT_READ_UNTRACKED`) to its prescribed fix. Read it whenever a Solid diagnostic code appears in test output or the browser console.
+- `node_modules/@solidjs/diagnostics/skills/agent-loops/SKILL.md` — how to capture reactive evidence (which scopes re-ran and why, wasted recomputes, cost tables) and assert budgets, in tests and against live pages.
+
+## Reactive diagnostics — capture evidence instead of guessing
+
+Use these whenever you are debugging reactivity (something doesn't update, updates too often, or is slow) or verifying a change didn't regress update granularity:
+
+- **In tests:** `captureArtifact()` from `@solidjs/diagnostics` wraps a scenario and returns a serializable artifact of diagnostics + rerun attribution; matchers from `@solidjs/diagnostics/vitest` (`toHaveNoDiagnostics`, `toStayWithinRerunBudget`, `toHaveNoWaste`, …) assert on it. No browser needed.
+- **Against the running dev server** (`diagnostics: true` in vite.config.ts; dev-only, no-op in builds). Requires an open page connected to the dev server (e.g. via a browser tool):
+  - `GET /__solid/diagnostics` — status and connected client count
+  - `POST /__solid/diagnostics` with JSON `{"method":"begin"}` then `{"method":"end"}` — capture a session into an artifact
+  - `{"method":"whyDidRun","params":{"name":"<scope name>"}}` — recorded re-runs of one named scope in the open session
+  - `{"method":"costs"}` — running cost tables for the open session
+
+Name your signals/memos/effects (the `{ name: "..." }` option) — attribution reports scopes by name.

--- a/solid-v2/with-unocss/package.json
+++ b/solid-v2/with-unocss/package.json
@@ -13,8 +13,9 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@solidjs/testing-library": "1.0.0-beta.2",
-    "@solidjs/vite-plugin": "^3.0.0-next.33",
+    "@solidjs/diagnostics": "^2.0.0-rc.3",
+    "@solidjs/testing-library": "^1.0.0-beta.2",
+    "@solidjs/vite-plugin": "^3.0.0-next.34",
     "@testing-library/jest-dom": "^6.6.3",
     "@unocss/preset-wind4": "^66.5.2",
     "@unocss/reset": "^66.5.2",
@@ -29,8 +30,8 @@
   },
   "dependencies": {
     "@solidjs/meta": "^1.0.0-next.2",
-    "@solidjs/router": "^2.0.0-next.16",
-    "@solidjs/web": "^2.0.0-rc.2",
-    "solid-js": "^2.0.0-rc.2"
+    "@solidjs/router": "^2.0.0-next.17",
+    "@solidjs/web": "^2.0.0-rc.3",
+    "solid-js": "^2.0.0-rc.3"
   }
 }

--- a/solid-v2/with-unocss/pnpm-lock.yaml
+++ b/solid-v2/with-unocss/pnpm-lock.yaml
@@ -10,23 +10,26 @@ importers:
     dependencies:
       '@solidjs/meta':
         specifier: ^1.0.0-next.2
-        version: 1.0.0-next.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)
+        version: 1.0.0-next.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/router':
-        specifier: ^2.0.0-next.16
-        version: 2.0.0-next.16(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)
+        specifier: ^2.0.0-next.17
+        version: 2.0.0-next.17(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/web':
-        specifier: ^2.0.0-rc.2
-        version: 2.0.0-rc.2(solid-js@2.0.0-rc.2)
+        specifier: ^2.0.0-rc.3
+        version: 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       solid-js:
-        specifier: ^2.0.0-rc.2
-        version: 2.0.0-rc.2
+        specifier: ^2.0.0-rc.3
+        version: 2.0.0-rc.3
     devDependencies:
+      '@solidjs/diagnostics':
+        specifier: ^2.0.0-rc.3
+        version: 2.0.0-rc.3(vitest@4.1.10(jsdom@25.0.1)(vite@8.2.1(jiti@2.7.0)))
       '@solidjs/testing-library':
-        specifier: 1.0.0-beta.2
-        version: 1.0.0-beta.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)
+        specifier: ^1.0.0-beta.2
+        version: 1.0.0-beta.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/vite-plugin':
-        specifier: ^3.0.0-next.33
-        version: 3.0.0-next.33(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.2)(vite@8.2.1(jiti@2.7.0))
+        specifier: ^3.0.0-next.34
+        version: 3.0.0-next.34(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.3)(vite@8.2.1(jiti@2.7.0))
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.10.0(@testing-library/dom@10.4.1)
@@ -189,53 +192,14 @@ packages:
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.42':
-    resolution: {integrity: sha512-ol24x9RW8loPyOTzC/mQzh/zAsrsPxyTG4WRxxRlwzNK2uBWIBftWN5IwmSV51zDQa7JcT6sE6kkXFCLUvsYIQ==}
-    peerDependencies:
-      '@babel/core': ^7.20.12
-
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
-    resolution: {integrity: sha512-7l575p7EQu16lssfbtgspSBWBSK5+car5NP4VYD/iJiK+Qd2VcMQMwaOjgA1xCs/P0S0l9EFY9BHGIJcHQTL+w==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
-    resolution: {integrity: sha512-NRbfI3HhBPsSrSQvSUfQXvPXfEKjUQKnbBVCDvcu7ISBPMQd+0yH9M+Qmlf7kVq4Ci9qa1HL5EA2jD22d2v73A==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
-    resolution: {integrity: sha512-/Gfa8j/YHBKK1i8b2VQw3ewBlA6qlEZSAn+b7g3z1g18WydPUI/TZWISKpgNxAtyl9m9MvwgbWA1HcHVkf4zyg==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
-    resolution: {integrity: sha512-gV4J4Sr1+6Awnkl5npREqPvxcDfgw4PGguTdFnsHVN9cxAFet3ujcCbWsAJ+QMBUQ8OT/LG6d4oJLlAkQ0D1fA==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
-    resolution: {integrity: sha512-YrzoB/YZtrmnGXhz3sxs7VeuAXT0JRc6NguNX8iDNt5p5fQ0QX+HR75GYMsxY9FceSVTHObrm3fA/8KGYo5z6Q==}
-    engines: {node: '>=14.0.0'}
-
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
-    resolution: {integrity: sha512-BNQEgny4zyjceZqCaRJDCrQ2oy6z7oXruAE/du2uJB7qLz/z24ISJVUKeKHPb5mRzHuSiTlDcK7pDzE7jPPXjg==}
-    cpu: [x64]
-    os: [win32]
-
-  '@dom-expressions/compiler@0.50.0-next.44':
-    resolution: {integrity: sha512-CBj0k+LcpCk8+nJGY7uvqxLC5NLxXTx9l0fuMZBBkBAOgVf5/IlMyMSpaYE5H5AkFiajR05NYvNR07R6e0KZ3w==}
-
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
-  '@emnapi/core@1.11.2':
-    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+  '@emnapi/core@1.11.3':
+    resolution: {integrity: sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==}
 
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
@@ -243,14 +207,17 @@ packages:
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
-  '@emnapi/runtime@1.11.2':
-    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@emnapi/wasi-threads@1.2.3':
+    resolution: {integrity: sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==}
 
   '@eslint-community/eslint-utils@4.10.1':
     resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
@@ -827,20 +794,67 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@solidjs/babel-plugin@2.0.0-rc.3':
+    resolution: {integrity: sha512-VLqCvvMukrACeMuF3uPTyx9l+qCQ9H1G25vOl7FXAdu9rMrLEKZ2IEoiUMczn0mhXAVeplJVEvr7+gSy5m4omA==}
+    peerDependencies:
+      '@babel/core': ^7.20.12
+
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.3':
+    resolution: {integrity: sha512-P9Ngf6KUwM+KGAAUZ40776+1utbk/n3+F+WhyyYm+rUpjO0um9EqBJLvafqEp6kGgSHQ2j5UhioqcuqhesMLbQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.3':
+    resolution: {integrity: sha512-PozalaeiMJxPF7H5ePpqOGM8F9H07sFsSGxyHHZiUn8c4HIBlsacNpc06gUcoJ1xzm7AvayNCV9BJOw2hQYaYg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3':
+    resolution: {integrity: sha512-riY4uwHCqq5vfrlYY7AK8xy/r/Wd98NCnbGqFsDb7bL7TNw398VuA5+hoK4cnsQJe4dqvI2zXFEdmP5xSNAFSQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3':
+    resolution: {integrity: sha512-y2GlcmfIqtWBrxOnvgLsGZvdH2tVK/9JzcFTUzWo5kjoiEy+VCV3NSNcBZrMbLJ7ozIDTiuWePZd/G5LphYdmA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3':
+    resolution: {integrity: sha512-mx7LnrAwKaXd9ZiaAwZeBlMjdWNdmR73F+3I1iOxSpH9Lh2Kyx9IIVff0a1AnwUy17tdDxXMbWxoI/ctYfZsdw==}
+    engines: {node: '>=14.0.0'}
+
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3':
+    resolution: {integrity: sha512-7MQDvdSI42/+lSac6L6WVgCYkUezzliLRoCjo7ultpN2hHy3XgohxvrWfE005OQEMg2pamzzFmfeIl8FUi2JRA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@solidjs/compiler@2.0.0-rc.3':
+    resolution: {integrity: sha512-gu2AnJwkrJfk3SBKGRxEUGuP/SZpwUGzHQS5zt56eNG4GFlEMyurahVRSLMWWBhtC1On7wH5SmLxybH2yDCqAg==}
+
+  '@solidjs/diagnostics@2.0.0-rc.3':
+    resolution: {integrity: sha512-fPb20MXqN7LpT02+kxfMBhY3reCKeh7vB++g9Su1EJZ6Ie0PeydyU/CnkUNa9gwLCMKoZG1x0pfAMb9yLGowtw==}
+    peerDependencies:
+      vitest: '>=2.0.0'
+    peerDependenciesMeta:
+      vitest:
+        optional: true
+
   '@solidjs/meta@1.0.0-next.2':
     resolution: {integrity: sha512-4aqPczFqDdep4JTAUXfh4nyfq7InbTgimd7NuN6ZWWE29UPv0uR5dyr53yFcf2YgVXjFdX+JGhXtsE0njGL+fA==}
     peerDependencies:
       '@solidjs/web': ^2.0.0-rc.0
       solid-js: ^2.0.0-rc.0
 
-  '@solidjs/router@2.0.0-next.16':
-    resolution: {integrity: sha512-sYaq5h4ISdDVZKhA1R0X4NHFg4Kao7HpK3QRfbFcE25/x2PFl4VxlHLZIoBUfv3T3L9g4GVTD376pvArwgGlDA==}
+  '@solidjs/router@2.0.0-next.17':
+    resolution: {integrity: sha512-LchYm3IZ3Y7vGPh/Jx6X8UjpBirQrz9ZoRQkgRpdz8A9C7eTiRXY326pJDcoYDXn7FzYtFpRCwsfBMxRDsFo6A==}
     peerDependencies:
-      '@solidjs/web': ^2.0.0-rc.0
-      solid-js: ^2.0.0-rc.0
+      '@solidjs/web': ^2.0.0-rc.1
+      solid-js: ^2.0.0-rc.1
 
-  '@solidjs/signals@2.0.0-rc.2':
-    resolution: {integrity: sha512-nJyXdBZJaYGqtDuQt8csE9LY9oNZV2fZfPRmJHQT9QjQEuHKQ1OaZScZ8YFaeATrnavzys4Ws95LnUdv8pCidQ==}
+  '@solidjs/signals@2.0.0-rc.3':
+    resolution: {integrity: sha512-/yPhTf3xS1FRR4MX8kTYCd4MjsFxzwkO+KyOTfbu35lTEiaJ4Fxy+JL91XonDzt31GV1mYaZ9CGD2TQIzvXuNA==}
 
   '@solidjs/testing-library@1.0.0-beta.2':
     resolution: {integrity: sha512-TLhQ5IUT/fdDfqa4X2rkQWB28Y+zEwi6mK/TVTeiQlEHG63eK2jfgwNYf2NtQoPh2c3ihLilsCzxABiSTP3JoQ==}
@@ -849,8 +863,8 @@ packages:
       '@solidjs/web': '>=2.0.0'
       solid-js: '>=2.0.0'
 
-  '@solidjs/vite-plugin@3.0.0-next.33':
-    resolution: {integrity: sha512-8c6twAU/ko9TUEr3koPnWQ1CzET+muZPJFaxBSLYv0M+WRgtmbjlHl9GxTSfm5dd23JDwGhBcv3gdxr2slV/wg==}
+  '@solidjs/vite-plugin@3.0.0-next.34':
+    resolution: {integrity: sha512-uDxBcBjbcS6k509TXTsNw4PjubT59eInzLAny43N5Ieoa4jROCaWV+EwxedPqtCF7nsHoKGgwC+ysu6w105G0A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@solidjs/start-devtools': ^1.0.0-next.2
@@ -864,10 +878,10 @@ packages:
       '@testing-library/jest-dom':
         optional: true
 
-  '@solidjs/web@2.0.0-rc.2':
-    resolution: {integrity: sha512-JazuW9NCI+kcpZXRq9J/DAGPmMd0pEWr3kuXFmPZV9tOviiTOHDXOf56pjbUFVDZd+120AKoe/ULmYdSDpJmsA==}
+  '@solidjs/web@2.0.0-rc.3':
+    resolution: {integrity: sha512-5ckKgOjem1pN5ADycOk6TjHmTtjbbN2fukqxo6RW3Oe3H7z0gaXWAdt8dLISto5/O4Nn8VxprFXFWpfy31+DUg==}
     peerDependencies:
-      solid-js: ^2.0.0-rc.2
+      solid-js: ^2.0.0-rc.3
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1096,21 +1110,12 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  babel-preset-solid@2.0.0-rc.0:
-    resolution: {integrity: sha512-Ap2/QQY3pICj+Q0VM/RnIOpZo7e6icZnUA0oBJuhqzoCrljqMNo3eFb2OeEa4pUQeFREJOlex4Bt1ggwrcgC8w==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-rc.0
-    peerDependenciesMeta:
-      solid-js:
-        optional: true
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  baseline-browser-mapping@2.11.13:
-    resolution: {integrity: sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==}
+  baseline-browser-mapping@2.11.19:
+    resolution: {integrity: sha512-Grytf1xOxOEMTGRwx6rLGKkTabd4vMg3VrKdj/7joCmV0qgh4QwMMO6xh34YEXQqirAuUdgQGa5orJQQ+69RBw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1135,8 +1140,8 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
-  caniuse-lite@1.0.30001809:
-    resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
+  caniuse-lite@1.0.30001810:
+    resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -1231,8 +1236,8 @@ packages:
   duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
 
-  electron-to-chromium@1.5.405:
-    resolution: {integrity: sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==}
+  electron-to-chromium@1.5.415:
+    resolution: {integrity: sha512-958V+Kbhtgz+SxXeEVKBjrlKRBIDAYvUJfwhjxMZ5S6ut9jAl7l9ZKBkBrvjyjZE36PabLUo2L8kEeV5O4vgJg==}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -1875,8 +1880,8 @@ packages:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
 
-  solid-js@2.0.0-rc.2:
-    resolution: {integrity: sha512-1C++20cho5f+omXbX6MIl+VrBZ+by6QkWpCtpbVmmUR80EGgH4irqV0UdP88GAYHx1U+FzpCcHxIGoA9raCyQA==}
+  solid-js@2.0.0-rc.3:
+    resolution: {integrity: sha512-pmW6bRoTvfp/rN4jN7JmLvSaoIpFt7wm0Hi3j508S/smuJqUbRg3dQEjOPTkAwHW+McYnXrMG7cJ4AMNpLevtQ==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2311,47 +2316,6 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.42(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
-      '@babel/types': 7.29.8
-      html-entities: 2.3.3
-      parse5: 7.3.0
-      validate-html-nesting: 1.2.4
-
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
-    dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
-      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
-    optional: true
-
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler@0.50.0-next.44':
-    optionalDependencies:
-      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.44
-      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.44
-      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.44
-      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.44
-      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.44
-      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.44
-
   '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -2364,9 +2328,9 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/core@1.11.2':
+  '@emnapi/core@1.11.3':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.2
+      '@emnapi/wasi-threads': 1.2.3
       tslib: 2.8.1
     optional: true
 
@@ -2380,7 +2344,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.11.2':
+  '@emnapi/runtime@1.11.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2391,6 +2355,11 @@ snapshots:
     optional: true
 
   '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2482,10 +2451,10 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -2742,34 +2711,81 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@solidjs/meta@1.0.0-next.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)':
+  '@solidjs/babel-plugin@2.0.0-rc.3(@babel/core@7.29.7)':
     dependencies:
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/types': 7.29.8
+      html-entities: 2.3.3
+      parse5: 7.3.0
+      validate-html-nesting: 1.2.4
 
-  '@solidjs/router@2.0.0-next.16(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)':
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3':
     dependencies:
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+    optional: true
 
-  '@solidjs/signals@2.0.0-rc.2': {}
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3':
+    optional: true
 
-  '@solidjs/testing-library@1.0.0-beta.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)':
+  '@solidjs/compiler@2.0.0-rc.3':
+    optionalDependencies:
+      '@solidjs/compiler-darwin-arm64': 2.0.0-rc.3
+      '@solidjs/compiler-darwin-x64': 2.0.0-rc.3
+      '@solidjs/compiler-linux-arm64-gnu': 2.0.0-rc.3
+      '@solidjs/compiler-linux-x64-gnu': 2.0.0-rc.3
+      '@solidjs/compiler-wasm32-wasi': 2.0.0-rc.3
+      '@solidjs/compiler-win32-x64-msvc': 2.0.0-rc.3
+
+  '@solidjs/diagnostics@2.0.0-rc.3(vitest@4.1.10(jsdom@25.0.1)(vite@8.2.1(jiti@2.7.0)))':
     dependencies:
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
+      '@solidjs/signals': 2.0.0-rc.3
+    optionalDependencies:
+      vitest: 4.1.10(jsdom@25.0.1)(vite@8.2.1(jiti@2.7.0))
+
+  '@solidjs/meta@1.0.0-next.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
+    dependencies:
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
+
+  '@solidjs/router@2.0.0-next.17(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
+    dependencies:
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
+
+  '@solidjs/signals@2.0.0-rc.3': {}
+
+  '@solidjs/testing-library@1.0.0-beta.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
+    dependencies:
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@testing-library/dom': 10.4.1
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
 
-  '@solidjs/vite-plugin@3.0.0-next.33(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.2)(vite@8.2.1(jiti@2.7.0))':
+  '@solidjs/vite-plugin@3.0.0-next.34(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.3)(vite@8.2.1(jiti@2.7.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/core': 7.29.7
-      '@dom-expressions/compiler': 0.50.0-next.44
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
+      '@solidjs/babel-plugin': 2.0.0-rc.3(@babel/core@7.29.7)
+      '@solidjs/compiler': 2.0.0-rc.3
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-rc.0(@babel/core@7.29.7)(solid-js@2.0.0-rc.2)
       merge-anything: 5.1.7
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
       vite: 8.2.1(jiti@2.7.0)
       vitefu: 1.1.3(vite@8.2.1(jiti@2.7.0))
     optionalDependencies:
@@ -2777,11 +2793,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2)':
+  '@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3)':
     dependencies:
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -3105,16 +3121,9 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  babel-preset-solid@2.0.0-rc.0(@babel/core@7.29.7)(solid-js@2.0.0-rc.2):
-    dependencies:
-      '@babel/core': 7.29.7
-      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.42(@babel/core@7.29.7)
-    optionalDependencies:
-      solid-js: 2.0.0-rc.2
-
   balanced-match@4.0.4: {}
 
-  baseline-browser-mapping@2.11.13: {}
+  baseline-browser-mapping@2.11.19: {}
 
   brace-expansion@5.0.9:
     dependencies:
@@ -3126,9 +3135,9 @@ snapshots:
 
   browserslist@4.28.8:
     dependencies:
-      baseline-browser-mapping: 2.11.13
-      caniuse-lite: 1.0.30001809
-      electron-to-chromium: 1.5.405
+      baseline-browser-mapping: 2.11.19
+      caniuse-lite: 1.0.30001810
+      electron-to-chromium: 1.5.415
       node-releases: 2.0.53
       update-browserslist-db: 1.3.1(browserslist@4.28.8)
 
@@ -3139,7 +3148,7 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
-  caniuse-lite@1.0.30001809: {}
+  caniuse-lite@1.0.30001810: {}
 
   chai@6.2.2: {}
 
@@ -3214,7 +3223,7 @@ snapshots:
 
   duplexer@0.1.2: {}
 
-  electron-to-chromium@1.5.405: {}
+  electron-to-chromium@1.5.415: {}
 
   entities@6.0.1: {}
 
@@ -3891,9 +3900,9 @@ snapshots:
       mrmime: 2.0.1
       totalist: 3.0.1
 
-  solid-js@2.0.0-rc.2:
+  solid-js@2.0.0-rc.3:
     dependencies:
-      '@solidjs/signals': 2.0.0-rc.2
+      '@solidjs/signals': 2.0.0-rc.3
       csstype: 3.2.3
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)

--- a/solid-v2/with-unocss/vite.config.ts
+++ b/solid-v2/with-unocss/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   plugins: [
     // `extensions` makes @solidjs/vite-plugin also compile the `?pick=` route
     // modules the fileRoutes plugin emits (their ids end in a query string).
-    solid({ start: true, extensions: ['.jsx', '.tsx'] }), // add `ssr: true` for streaming SSR
+    solid({ start: true, extensions: ['.jsx', '.tsx'], diagnostics: true }), // add `ssr: true` for streaming SSR
     fileRoutes({ types: true }),
     // Scans source files for class names and serves their CSS as the
     // virtual:uno.css module (imported by src/App.tsx). Config can grow

--- a/solid-v2/with-vitest-browser-mode/AGENTS.md
+++ b/solid-v2/with-vitest-browser-mode/AGENTS.md
@@ -1,0 +1,23 @@
+# Agent Guide
+
+This is a SolidJS 2.x project. Solid is not React: components run once (there is no re-render), reactivity is fine-grained through signals, and effects/memos have Solid-specific semantics. Do not port React patterns.
+
+## Versioned skills (in node_modules — read on demand)
+
+The installed packages ship agent skills that match their exact installed versions:
+
+- `node_modules/solid-js/skills/reactivity-diagnostics/SKILL.md` — repair guide mapping every dev-mode diagnostic code (e.g. `REACTIVE_WRITE_IN_OWNED_SCOPE`, `STRICT_READ_UNTRACKED`) to its prescribed fix. Read it whenever a Solid diagnostic code appears in test output or the browser console.
+- `node_modules/@solidjs/diagnostics/skills/agent-loops/SKILL.md` — how to capture reactive evidence (which scopes re-ran and why, wasted recomputes, cost tables) and assert budgets, in tests and against live pages.
+
+## Reactive diagnostics — capture evidence instead of guessing
+
+Use these whenever you are debugging reactivity (something doesn't update, updates too often, or is slow) or verifying a change didn't regress update granularity:
+
+- **In tests:** `captureArtifact()` from `@solidjs/diagnostics` wraps a scenario and returns a serializable artifact of diagnostics + rerun attribution; matchers from `@solidjs/diagnostics/vitest` (`toHaveNoDiagnostics`, `toStayWithinRerunBudget`, `toHaveNoWaste`, …) assert on it. No browser needed.
+- **Against the running dev server** (`diagnostics: true` in vite.config.ts; dev-only, no-op in builds). Requires an open page connected to the dev server (e.g. via a browser tool):
+  - `GET /__solid/diagnostics` — status and connected client count
+  - `POST /__solid/diagnostics` with JSON `{"method":"begin"}` then `{"method":"end"}` — capture a session into an artifact
+  - `{"method":"whyDidRun","params":{"name":"<scope name>"}}` — recorded re-runs of one named scope in the open session
+  - `{"method":"costs"}` — running cost tables for the open session
+
+Name your signals/memos/effects (the `{ name: "..." }` option) — attribution reports scopes by name.

--- a/solid-v2/with-vitest-browser-mode/package.json
+++ b/solid-v2/with-vitest-browser-mode/package.json
@@ -13,8 +13,9 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@solidjs/testing-library": "1.0.0-beta.2",
-    "@solidjs/vite-plugin": "^3.0.0-next.33",
+    "@solidjs/diagnostics": "^2.0.0-rc.3",
+    "@solidjs/testing-library": "^1.0.0-beta.2",
+    "@solidjs/vite-plugin": "^3.0.0-next.34",
     "@testing-library/jest-dom": "^6.6.3",
     "@vitest/browser-playwright": "^4.0.0",
     "eslint-plugin-solid": "~0.16.0",
@@ -27,8 +28,8 @@
   },
   "dependencies": {
     "@solidjs/meta": "^1.0.0-next.2",
-    "@solidjs/router": "^2.0.0-next.16",
-    "@solidjs/web": "^2.0.0-rc.2",
-    "solid-js": "^2.0.0-rc.2"
+    "@solidjs/router": "^2.0.0-next.17",
+    "@solidjs/web": "^2.0.0-rc.3",
+    "solid-js": "^2.0.0-rc.3"
   }
 }

--- a/solid-v2/with-vitest-browser-mode/pnpm-lock.yaml
+++ b/solid-v2/with-vitest-browser-mode/pnpm-lock.yaml
@@ -10,23 +10,26 @@ importers:
     dependencies:
       '@solidjs/meta':
         specifier: ^1.0.0-next.2
-        version: 1.0.0-next.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)
+        version: 1.0.0-next.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/router':
-        specifier: ^2.0.0-next.16
-        version: 2.0.0-next.16(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)
+        specifier: ^2.0.0-next.17
+        version: 2.0.0-next.17(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/web':
-        specifier: ^2.0.0-rc.2
-        version: 2.0.0-rc.2(solid-js@2.0.0-rc.2)
+        specifier: ^2.0.0-rc.3
+        version: 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       solid-js:
-        specifier: ^2.0.0-rc.2
-        version: 2.0.0-rc.2
+        specifier: ^2.0.0-rc.3
+        version: 2.0.0-rc.3
     devDependencies:
+      '@solidjs/diagnostics':
+        specifier: ^2.0.0-rc.3
+        version: 2.0.0-rc.3(vitest@4.1.10)
       '@solidjs/testing-library':
-        specifier: 1.0.0-beta.2
-        version: 1.0.0-beta.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)
+        specifier: ^1.0.0-beta.2
+        version: 1.0.0-beta.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/vite-plugin':
-        specifier: ^3.0.0-next.33
-        version: 3.0.0-next.33(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.2)(vite@8.2.1)
+        specifier: ^3.0.0-next.34
+        version: 3.0.0-next.34(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.3)(vite@8.2.1)
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.10.0(@testing-library/dom@10.4.1)
@@ -152,59 +155,23 @@ packages:
   '@blazediff/core@1.9.1':
     resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.42':
-    resolution: {integrity: sha512-ol24x9RW8loPyOTzC/mQzh/zAsrsPxyTG4WRxxRlwzNK2uBWIBftWN5IwmSV51zDQa7JcT6sE6kkXFCLUvsYIQ==}
-    peerDependencies:
-      '@babel/core': ^7.20.12
-
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
-    resolution: {integrity: sha512-7l575p7EQu16lssfbtgspSBWBSK5+car5NP4VYD/iJiK+Qd2VcMQMwaOjgA1xCs/P0S0l9EFY9BHGIJcHQTL+w==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
-    resolution: {integrity: sha512-NRbfI3HhBPsSrSQvSUfQXvPXfEKjUQKnbBVCDvcu7ISBPMQd+0yH9M+Qmlf7kVq4Ci9qa1HL5EA2jD22d2v73A==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
-    resolution: {integrity: sha512-/Gfa8j/YHBKK1i8b2VQw3ewBlA6qlEZSAn+b7g3z1g18WydPUI/TZWISKpgNxAtyl9m9MvwgbWA1HcHVkf4zyg==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
-    resolution: {integrity: sha512-gV4J4Sr1+6Awnkl5npREqPvxcDfgw4PGguTdFnsHVN9cxAFet3ujcCbWsAJ+QMBUQ8OT/LG6d4oJLlAkQ0D1fA==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
-    resolution: {integrity: sha512-YrzoB/YZtrmnGXhz3sxs7VeuAXT0JRc6NguNX8iDNt5p5fQ0QX+HR75GYMsxY9FceSVTHObrm3fA/8KGYo5z6Q==}
-    engines: {node: '>=14.0.0'}
-
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
-    resolution: {integrity: sha512-BNQEgny4zyjceZqCaRJDCrQ2oy6z7oXruAE/du2uJB7qLz/z24ISJVUKeKHPb5mRzHuSiTlDcK7pDzE7jPPXjg==}
-    cpu: [x64]
-    os: [win32]
-
-  '@dom-expressions/compiler@0.50.0-next.44':
-    resolution: {integrity: sha512-CBj0k+LcpCk8+nJGY7uvqxLC5NLxXTx9l0fuMZBBkBAOgVf5/IlMyMSpaYE5H5AkFiajR05NYvNR07R6e0KZ3w==}
-
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
-  '@emnapi/core@1.11.2':
-    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+  '@emnapi/core@1.11.3':
+    resolution: {integrity: sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==}
 
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
-  '@emnapi/runtime@1.11.2':
-    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@emnapi/wasi-threads@1.2.3':
+    resolution: {integrity: sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==}
 
   '@eslint-community/eslint-utils@4.10.1':
     resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
@@ -642,20 +609,67 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@solidjs/babel-plugin@2.0.0-rc.3':
+    resolution: {integrity: sha512-VLqCvvMukrACeMuF3uPTyx9l+qCQ9H1G25vOl7FXAdu9rMrLEKZ2IEoiUMczn0mhXAVeplJVEvr7+gSy5m4omA==}
+    peerDependencies:
+      '@babel/core': ^7.20.12
+
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.3':
+    resolution: {integrity: sha512-P9Ngf6KUwM+KGAAUZ40776+1utbk/n3+F+WhyyYm+rUpjO0um9EqBJLvafqEp6kGgSHQ2j5UhioqcuqhesMLbQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.3':
+    resolution: {integrity: sha512-PozalaeiMJxPF7H5ePpqOGM8F9H07sFsSGxyHHZiUn8c4HIBlsacNpc06gUcoJ1xzm7AvayNCV9BJOw2hQYaYg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3':
+    resolution: {integrity: sha512-riY4uwHCqq5vfrlYY7AK8xy/r/Wd98NCnbGqFsDb7bL7TNw398VuA5+hoK4cnsQJe4dqvI2zXFEdmP5xSNAFSQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3':
+    resolution: {integrity: sha512-y2GlcmfIqtWBrxOnvgLsGZvdH2tVK/9JzcFTUzWo5kjoiEy+VCV3NSNcBZrMbLJ7ozIDTiuWePZd/G5LphYdmA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3':
+    resolution: {integrity: sha512-mx7LnrAwKaXd9ZiaAwZeBlMjdWNdmR73F+3I1iOxSpH9Lh2Kyx9IIVff0a1AnwUy17tdDxXMbWxoI/ctYfZsdw==}
+    engines: {node: '>=14.0.0'}
+
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3':
+    resolution: {integrity: sha512-7MQDvdSI42/+lSac6L6WVgCYkUezzliLRoCjo7ultpN2hHy3XgohxvrWfE005OQEMg2pamzzFmfeIl8FUi2JRA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@solidjs/compiler@2.0.0-rc.3':
+    resolution: {integrity: sha512-gu2AnJwkrJfk3SBKGRxEUGuP/SZpwUGzHQS5zt56eNG4GFlEMyurahVRSLMWWBhtC1On7wH5SmLxybH2yDCqAg==}
+
+  '@solidjs/diagnostics@2.0.0-rc.3':
+    resolution: {integrity: sha512-fPb20MXqN7LpT02+kxfMBhY3reCKeh7vB++g9Su1EJZ6Ie0PeydyU/CnkUNa9gwLCMKoZG1x0pfAMb9yLGowtw==}
+    peerDependencies:
+      vitest: '>=2.0.0'
+    peerDependenciesMeta:
+      vitest:
+        optional: true
+
   '@solidjs/meta@1.0.0-next.2':
     resolution: {integrity: sha512-4aqPczFqDdep4JTAUXfh4nyfq7InbTgimd7NuN6ZWWE29UPv0uR5dyr53yFcf2YgVXjFdX+JGhXtsE0njGL+fA==}
     peerDependencies:
       '@solidjs/web': ^2.0.0-rc.0
       solid-js: ^2.0.0-rc.0
 
-  '@solidjs/router@2.0.0-next.16':
-    resolution: {integrity: sha512-sYaq5h4ISdDVZKhA1R0X4NHFg4Kao7HpK3QRfbFcE25/x2PFl4VxlHLZIoBUfv3T3L9g4GVTD376pvArwgGlDA==}
+  '@solidjs/router@2.0.0-next.17':
+    resolution: {integrity: sha512-LchYm3IZ3Y7vGPh/Jx6X8UjpBirQrz9ZoRQkgRpdz8A9C7eTiRXY326pJDcoYDXn7FzYtFpRCwsfBMxRDsFo6A==}
     peerDependencies:
-      '@solidjs/web': ^2.0.0-rc.0
-      solid-js: ^2.0.0-rc.0
+      '@solidjs/web': ^2.0.0-rc.1
+      solid-js: ^2.0.0-rc.1
 
-  '@solidjs/signals@2.0.0-rc.2':
-    resolution: {integrity: sha512-nJyXdBZJaYGqtDuQt8csE9LY9oNZV2fZfPRmJHQT9QjQEuHKQ1OaZScZ8YFaeATrnavzys4Ws95LnUdv8pCidQ==}
+  '@solidjs/signals@2.0.0-rc.3':
+    resolution: {integrity: sha512-/yPhTf3xS1FRR4MX8kTYCd4MjsFxzwkO+KyOTfbu35lTEiaJ4Fxy+JL91XonDzt31GV1mYaZ9CGD2TQIzvXuNA==}
 
   '@solidjs/testing-library@1.0.0-beta.2':
     resolution: {integrity: sha512-TLhQ5IUT/fdDfqa4X2rkQWB28Y+zEwi6mK/TVTeiQlEHG63eK2jfgwNYf2NtQoPh2c3ihLilsCzxABiSTP3JoQ==}
@@ -664,8 +678,8 @@ packages:
       '@solidjs/web': '>=2.0.0'
       solid-js: '>=2.0.0'
 
-  '@solidjs/vite-plugin@3.0.0-next.33':
-    resolution: {integrity: sha512-8c6twAU/ko9TUEr3koPnWQ1CzET+muZPJFaxBSLYv0M+WRgtmbjlHl9GxTSfm5dd23JDwGhBcv3gdxr2slV/wg==}
+  '@solidjs/vite-plugin@3.0.0-next.34':
+    resolution: {integrity: sha512-uDxBcBjbcS6k509TXTsNw4PjubT59eInzLAny43N5Ieoa4jROCaWV+EwxedPqtCF7nsHoKGgwC+ysu6w105G0A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@solidjs/start-devtools': ^1.0.0-next.2
@@ -679,10 +693,10 @@ packages:
       '@testing-library/jest-dom':
         optional: true
 
-  '@solidjs/web@2.0.0-rc.2':
-    resolution: {integrity: sha512-JazuW9NCI+kcpZXRq9J/DAGPmMd0pEWr3kuXFmPZV9tOviiTOHDXOf56pjbUFVDZd+120AKoe/ULmYdSDpJmsA==}
+  '@solidjs/web@2.0.0-rc.3':
+    resolution: {integrity: sha512-5ckKgOjem1pN5ADycOk6TjHmTtjbbN2fukqxo6RW3Oe3H7z0gaXWAdt8dLISto5/O4Nn8VxprFXFWpfy31+DUg==}
     peerDependencies:
-      solid-js: ^2.0.0-rc.2
+      solid-js: ^2.0.0-rc.3
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -846,21 +860,12 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  babel-preset-solid@2.0.0-rc.0:
-    resolution: {integrity: sha512-Ap2/QQY3pICj+Q0VM/RnIOpZo7e6icZnUA0oBJuhqzoCrljqMNo3eFb2OeEa4pUQeFREJOlex4Bt1ggwrcgC8w==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-rc.0
-    peerDependenciesMeta:
-      solid-js:
-        optional: true
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  baseline-browser-mapping@2.11.13:
-    resolution: {integrity: sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==}
+  baseline-browser-mapping@2.11.19:
+    resolution: {integrity: sha512-Grytf1xOxOEMTGRwx6rLGKkTabd4vMg3VrKdj/7joCmV0qgh4QwMMO6xh34YEXQqirAuUdgQGa5orJQQ+69RBw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -877,8 +882,8 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
-  caniuse-lite@1.0.30001809:
-    resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
+  caniuse-lite@1.0.30001810:
+    resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -923,8 +928,8 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  electron-to-chromium@1.5.405:
-    resolution: {integrity: sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==}
+  electron-to-chromium@1.5.415:
+    resolution: {integrity: sha512-958V+Kbhtgz+SxXeEVKBjrlKRBIDAYvUJfwhjxMZ5S6ut9jAl7l9ZKBkBrvjyjZE36PabLUo2L8kEeV5O4vgJg==}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -1425,8 +1430,8 @@ packages:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
 
-  solid-js@2.0.0-rc.2:
-    resolution: {integrity: sha512-1C++20cho5f+omXbX6MIl+VrBZ+by6QkWpCtpbVmmUR80EGgH4irqV0UdP88GAYHx1U+FzpCcHxIGoA9raCyQA==}
+  solid-js@2.0.0-rc.3:
+    resolution: {integrity: sha512-pmW6bRoTvfp/rN4jN7JmLvSaoIpFt7wm0Hi3j508S/smuJqUbRg3dQEjOPTkAwHW+McYnXrMG7cJ4AMNpLevtQ==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -1747,56 +1752,15 @@ snapshots:
 
   '@blazediff/core@1.9.1': {}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.42(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
-      '@babel/types': 7.29.8
-      html-entities: 2.3.3
-      parse5: 7.3.0
-      validate-html-nesting: 1.2.4
-
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
-    dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
-      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
-    optional: true
-
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler@0.50.0-next.44':
-    optionalDependencies:
-      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.44
-      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.44
-      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.44
-      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.44
-      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.44
-      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.44
-
   '@emnapi/core@1.11.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/core@1.11.2':
+  '@emnapi/core@1.11.3':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.2
+      '@emnapi/wasi-threads': 1.2.3
       tslib: 2.8.1
     optional: true
 
@@ -1805,12 +1769,17 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.11.2':
+  '@emnapi/runtime@1.11.3':
     dependencies:
       tslib: 2.8.1
     optional: true
 
   '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -1887,10 +1856,10 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -2077,34 +2046,81 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@solidjs/meta@1.0.0-next.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)':
+  '@solidjs/babel-plugin@2.0.0-rc.3(@babel/core@7.29.7)':
     dependencies:
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/types': 7.29.8
+      html-entities: 2.3.3
+      parse5: 7.3.0
+      validate-html-nesting: 1.2.4
 
-  '@solidjs/router@2.0.0-next.16(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)':
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3':
     dependencies:
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
-      solid-js: 2.0.0-rc.2
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+    optional: true
 
-  '@solidjs/signals@2.0.0-rc.2': {}
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3':
+    optional: true
 
-  '@solidjs/testing-library@1.0.0-beta.2(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(solid-js@2.0.0-rc.2)':
+  '@solidjs/compiler@2.0.0-rc.3':
+    optionalDependencies:
+      '@solidjs/compiler-darwin-arm64': 2.0.0-rc.3
+      '@solidjs/compiler-darwin-x64': 2.0.0-rc.3
+      '@solidjs/compiler-linux-arm64-gnu': 2.0.0-rc.3
+      '@solidjs/compiler-linux-x64-gnu': 2.0.0-rc.3
+      '@solidjs/compiler-wasm32-wasi': 2.0.0-rc.3
+      '@solidjs/compiler-win32-x64-msvc': 2.0.0-rc.3
+
+  '@solidjs/diagnostics@2.0.0-rc.3(vitest@4.1.10)':
     dependencies:
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
+      '@solidjs/signals': 2.0.0-rc.3
+    optionalDependencies:
+      vitest: 4.1.10(@vitest/browser-playwright@4.1.10)(vite@8.2.1)
+
+  '@solidjs/meta@1.0.0-next.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
+    dependencies:
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
+
+  '@solidjs/router@2.0.0-next.17(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
+    dependencies:
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
+      solid-js: 2.0.0-rc.3
+
+  '@solidjs/signals@2.0.0-rc.3': {}
+
+  '@solidjs/testing-library@1.0.0-beta.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
+    dependencies:
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@testing-library/dom': 10.4.1
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
 
-  '@solidjs/vite-plugin@3.0.0-next.33(@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.2)(vite@8.2.1)':
+  '@solidjs/vite-plugin@3.0.0-next.34(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(solid-js@2.0.0-rc.3)(vite@8.2.1)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/core': 7.29.7
-      '@dom-expressions/compiler': 0.50.0-next.44
-      '@solidjs/web': 2.0.0-rc.2(solid-js@2.0.0-rc.2)
+      '@solidjs/babel-plugin': 2.0.0-rc.3(@babel/core@7.29.7)
+      '@solidjs/compiler': 2.0.0-rc.3
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-rc.0(@babel/core@7.29.7)(solid-js@2.0.0-rc.2)
       merge-anything: 5.1.7
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
       vite: 8.2.1
       vitefu: 1.1.3(vite@8.2.1)
     optionalDependencies:
@@ -2112,11 +2128,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@solidjs/web@2.0.0-rc.2(solid-js@2.0.0-rc.2)':
+  '@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3)':
     dependencies:
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
-      solid-js: 2.0.0-rc.2
+      solid-js: 2.0.0-rc.3
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -2335,16 +2351,9 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  babel-preset-solid@2.0.0-rc.0(@babel/core@7.29.7)(solid-js@2.0.0-rc.2):
-    dependencies:
-      '@babel/core': 7.29.7
-      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.42(@babel/core@7.29.7)
-    optionalDependencies:
-      solid-js: 2.0.0-rc.2
-
   balanced-match@4.0.4: {}
 
-  baseline-browser-mapping@2.11.13: {}
+  baseline-browser-mapping@2.11.19: {}
 
   brace-expansion@5.0.9:
     dependencies:
@@ -2356,13 +2365,13 @@ snapshots:
 
   browserslist@4.28.8:
     dependencies:
-      baseline-browser-mapping: 2.11.13
-      caniuse-lite: 1.0.30001809
-      electron-to-chromium: 1.5.405
+      baseline-browser-mapping: 2.11.19
+      caniuse-lite: 1.0.30001810
+      electron-to-chromium: 1.5.415
       node-releases: 2.0.53
       update-browserslist-db: 1.3.1(browserslist@4.28.8)
 
-  caniuse-lite@1.0.30001809: {}
+  caniuse-lite@1.0.30001810: {}
 
   chai@6.2.2: {}
 
@@ -2392,7 +2401,7 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  electron-to-chromium@1.5.405: {}
+  electron-to-chromium@1.5.415: {}
 
   entities@6.0.1: {}
 
@@ -2870,9 +2879,9 @@ snapshots:
       mrmime: 2.0.1
       totalist: 3.0.1
 
-  solid-js@2.0.0-rc.2:
+  solid-js@2.0.0-rc.3:
     dependencies:
-      '@solidjs/signals': 2.0.0-rc.2
+      '@solidjs/signals': 2.0.0-rc.3
       csstype: 3.2.3
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)

--- a/solid-v2/with-vitest-browser-mode/vite.config.ts
+++ b/solid-v2/with-vitest-browser-mode/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   plugins: [
     // `extensions` makes @solidjs/vite-plugin also compile the `?pick=` route
     // modules the fileRoutes plugin emits (their ids end in a query string).
-    solid({ start: true, extensions: ['.jsx', '.tsx'] }), // add `ssr: true` for streaming SSR
+    solid({ start: true, extensions: ['.jsx', '.tsx'], diagnostics: true }), // add `ssr: true` for streaming SSR
     fileRoutes({ types: true }),
   ],
   server: {


### PR DESCRIPTION
## Summary
- Enables `diagnostics: true` in every solid-v2 template's `solid()` plugin call — dev-only `/__solid/diagnostics` endpoint plus the injected browser bridge; a no-op in builds.
- Adds `@solidjs/diagnostics` (devDependency, `^2.0.0-rc.3`) so the capture/assertion harness ships with every scaffolded app.
- Adds a thin `AGENTS.md` to each template pointing agents at the versioned skills inside `node_modules` (solid-js reactivity repair guide, diagnostics agent loops) and documenting the endpoint protocol. Discovery lives in the scaffold; the actual guidance stays versioned with the installed packages.
- Bumps solid deps in-range (solid-js/web rc.3, vite-plugin next.34, router next.17) and converts remaining exact pins on solid packages to caret ranges.

## Validation
- Endpoint and full capture loop (`begin` → `whyDidRun` → `end`) verified against a scaffolded bare template on the published packages.
- Blind agent test: an agent given only a symptom ("total never updates") on a fresh scaffold found `AGENTS.md` unprompted, followed both skills, identified the seeded stale-closure bug via `STRICT_READ_UNTRACKED` plus a `captureArtifact` repro, and verified its fix with rerun attribution before reporting.

Made with [Cursor](https://cursor.com)