### PR TITLE
solid-v2: bump eslint-plugin-solid to 0.16.1

### DIFF
--- a/solid-v2/bare/package.json
+++ b/solid-v2/bare/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@solidjs/diagnostics": "^2.0.0-rc.3",
     "@solidjs/vite-plugin": "^3.0.0-next.34",
-    "eslint-plugin-solid": "~0.16.0",
+    "eslint-plugin-solid": "~0.16.1",
     "oxlint": "~1.79.0",
     "typescript": "^5.9.2",
     "vite": "^8.1.5"

--- a/solid-v2/bare/pnpm-lock.yaml
+++ b/solid-v2/bare/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: ^3.0.0-next.34
         version: 3.0.0-next.34(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.2.1)
       eslint-plugin-solid:
-        specifier: ~0.16.0
-        version: 0.16.0(eslint@10.8.1)(typescript@5.9.3)
+        specifier: ~0.16.1
+        version: 0.16.1(eslint@10.8.1)(typescript@5.9.3)
       oxlint:
         specifier: ~1.79.0
         version: 1.79.0
@@ -627,8 +627,8 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-plugin-solid@0.16.0:
-    resolution: {integrity: sha512-q45VUvh3kv9ZHoVWZrep/KJFA7qqBH0khHuEEp0sCzEDuM3FtHFqK6fLWFIIIDGVQ8aFouUHROaOXVi8GgzShA==}
+  eslint-plugin-solid@0.16.1:
+    resolution: {integrity: sha512-RUd46y3Y2acT4//hxSut1UTGnDoZMWEhrplyE0cK0E3cWwvIsfui5HkG7cubQ95TntVacVHe+uYh97PSm0id4A==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       eslint: ^9.0.0 || ^10.0.0
@@ -1613,7 +1613,7 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-solid@0.16.0(eslint@10.8.1)(typescript@5.9.3):
+  eslint-plugin-solid@0.16.1(eslint@10.8.1)(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/utils': 8.67.0(eslint@10.8.1)(typescript@5.9.3)
       eslint: 10.8.1

--- a/solid-v2/basic/package.json
+++ b/solid-v2/basic/package.json
@@ -17,7 +17,7 @@
     "@solidjs/testing-library": "^1.0.0-beta.2",
     "@solidjs/vite-plugin": "^3.0.0-next.34",
     "@testing-library/jest-dom": "^6.6.3",
-    "eslint-plugin-solid": "~0.16.0",
+    "eslint-plugin-solid": "~0.16.1",
     "filesystem-routing": "0.2.1",
     "jsdom": "^25.0.1",
     "oxlint": "~1.79.0",

--- a/solid-v2/basic/pnpm-lock.yaml
+++ b/solid-v2/basic/pnpm-lock.yaml
@@ -34,8 +34,8 @@ importers:
         specifier: ^6.6.3
         version: 6.10.0(@testing-library/dom@10.4.1)
       eslint-plugin-solid:
-        specifier: ~0.16.0
-        version: 0.16.0(eslint@10.8.1)(typescript@5.9.3)
+        specifier: ~0.16.1
+        version: 0.16.1(eslint@10.8.1)(typescript@5.9.3)
       filesystem-routing:
         specifier: 0.2.1
         version: 0.2.1(vite@8.2.1)
@@ -1007,8 +1007,8 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-plugin-solid@0.16.0:
-    resolution: {integrity: sha512-q45VUvh3kv9ZHoVWZrep/KJFA7qqBH0khHuEEp0sCzEDuM3FtHFqK6fLWFIIIDGVQ8aFouUHROaOXVi8GgzShA==}
+  eslint-plugin-solid@0.16.1:
+    resolution: {integrity: sha512-RUd46y3Y2acT4//hxSut1UTGnDoZMWEhrplyE0cK0E3cWwvIsfui5HkG7cubQ95TntVacVHe+uYh97PSm0id4A==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       eslint: ^9.0.0 || ^10.0.0
@@ -2619,7 +2619,7 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-solid@0.16.0(eslint@10.8.1)(typescript@5.9.3):
+  eslint-plugin-solid@0.16.1(eslint@10.8.1)(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/utils': 8.67.0(eslint@10.8.1)(typescript@5.9.3)
       eslint: 10.8.1

--- a/solid-v2/fullstack-tanstack/package.json
+++ b/solid-v2/fullstack-tanstack/package.json
@@ -19,7 +19,7 @@
     "@tanstack/router-plugin": "1.168.27",
     "@testing-library/jest-dom": "^6.6.3",
     "@types/node": "^26.2.0",
-    "eslint-plugin-solid": "~0.16.0",
+    "eslint-plugin-solid": "~0.16.1",
     "filesystem-routing": "0.2.1",
     "jsdom": "^25.0.1",
     "oxlint": "~1.79.0",

--- a/solid-v2/fullstack-tanstack/pnpm-lock.yaml
+++ b/solid-v2/fullstack-tanstack/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: ^26.2.0
         version: 26.2.0
       eslint-plugin-solid:
-        specifier: ~0.16.0
-        version: 0.16.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)
+        specifier: ~0.16.1
+        version: 0.16.1(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)
       filesystem-routing:
         specifier: 0.2.1
         version: 0.2.1(vite@8.2.1(@types/node@26.2.0)(jiti@2.7.0))
@@ -1172,8 +1172,8 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-plugin-solid@0.16.0:
-    resolution: {integrity: sha512-q45VUvh3kv9ZHoVWZrep/KJFA7qqBH0khHuEEp0sCzEDuM3FtHFqK6fLWFIIIDGVQ8aFouUHROaOXVi8GgzShA==}
+  eslint-plugin-solid@0.16.1:
+    resolution: {integrity: sha512-RUd46y3Y2acT4//hxSut1UTGnDoZMWEhrplyE0cK0E3cWwvIsfui5HkG7cubQ95TntVacVHe+uYh97PSm0id4A==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       eslint: ^9.0.0 || ^10.0.0
@@ -3070,7 +3070,7 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-solid@0.16.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3):
+  eslint-plugin-solid@0.16.1(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/utils': 8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)
       eslint: 10.8.1(jiti@2.7.0)

--- a/solid-v2/fullstack/package.json
+++ b/solid-v2/fullstack/package.json
@@ -18,7 +18,7 @@
     "@solidjs/vite-plugin": "^3.0.0-next.34",
     "@testing-library/jest-dom": "^6.6.3",
     "@types/node": "^26.2.0",
-    "eslint-plugin-solid": "~0.16.0",
+    "eslint-plugin-solid": "~0.16.1",
     "filesystem-routing": "0.2.1",
     "jsdom": "^25.0.1",
     "oxlint": "~1.79.0",

--- a/solid-v2/fullstack/pnpm-lock.yaml
+++ b/solid-v2/fullstack/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
         specifier: ^26.2.0
         version: 26.2.0
       eslint-plugin-solid:
-        specifier: ~0.16.0
-        version: 0.16.0(eslint@10.8.1)(typescript@5.9.3)
+        specifier: ~0.16.1
+        version: 0.16.1(eslint@10.8.1)(typescript@5.9.3)
       filesystem-routing:
         specifier: 0.2.1
         version: 0.2.1(vite@8.2.1(@types/node@26.2.0))
@@ -1025,8 +1025,8 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-plugin-solid@0.16.0:
-    resolution: {integrity: sha512-q45VUvh3kv9ZHoVWZrep/KJFA7qqBH0khHuEEp0sCzEDuM3FtHFqK6fLWFIIIDGVQ8aFouUHROaOXVi8GgzShA==}
+  eslint-plugin-solid@0.16.1:
+    resolution: {integrity: sha512-RUd46y3Y2acT4//hxSut1UTGnDoZMWEhrplyE0cK0E3cWwvIsfui5HkG7cubQ95TntVacVHe+uYh97PSm0id4A==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       eslint: ^9.0.0 || ^10.0.0
@@ -2658,7 +2658,7 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-solid@0.16.0(eslint@10.8.1)(typescript@5.9.3):
+  eslint-plugin-solid@0.16.1(eslint@10.8.1)(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/utils': 8.67.0(eslint@10.8.1)(typescript@5.9.3)
       eslint: 10.8.1

--- a/solid-v2/with-bootstrap/package.json
+++ b/solid-v2/with-bootstrap/package.json
@@ -17,7 +17,7 @@
     "@solidjs/testing-library": "^1.0.0-beta.2",
     "@solidjs/vite-plugin": "^3.0.0-next.34",
     "@testing-library/jest-dom": "^6.6.3",
-    "eslint-plugin-solid": "~0.16.0",
+    "eslint-plugin-solid": "~0.16.1",
     "filesystem-routing": "0.2.1",
     "jsdom": "^25.0.1",
     "oxlint": "~1.79.0",

--- a/solid-v2/with-bootstrap/pnpm-lock.yaml
+++ b/solid-v2/with-bootstrap/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: ^6.6.3
         version: 6.10.0(@testing-library/dom@10.4.1)
       eslint-plugin-solid:
-        specifier: ~0.16.0
-        version: 0.16.0(eslint@10.8.1)(typescript@5.9.3)
+        specifier: ~0.16.1
+        version: 0.16.1(eslint@10.8.1)(typescript@5.9.3)
       filesystem-routing:
         specifier: 0.2.1
         version: 0.2.1(vite@8.2.1)
@@ -1018,8 +1018,8 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-plugin-solid@0.16.0:
-    resolution: {integrity: sha512-q45VUvh3kv9ZHoVWZrep/KJFA7qqBH0khHuEEp0sCzEDuM3FtHFqK6fLWFIIIDGVQ8aFouUHROaOXVi8GgzShA==}
+  eslint-plugin-solid@0.16.1:
+    resolution: {integrity: sha512-RUd46y3Y2acT4//hxSut1UTGnDoZMWEhrplyE0cK0E3cWwvIsfui5HkG7cubQ95TntVacVHe+uYh97PSm0id4A==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       eslint: ^9.0.0 || ^10.0.0
@@ -2636,7 +2636,7 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-solid@0.16.0(eslint@10.8.1)(typescript@5.9.3):
+  eslint-plugin-solid@0.16.1(eslint@10.8.1)(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/utils': 8.67.0(eslint@10.8.1)(typescript@5.9.3)
       eslint: 10.8.1

--- a/solid-v2/with-sass/package.json
+++ b/solid-v2/with-sass/package.json
@@ -17,7 +17,7 @@
     "@solidjs/testing-library": "^1.0.0-beta.2",
     "@solidjs/vite-plugin": "^3.0.0-next.34",
     "@testing-library/jest-dom": "^6.6.3",
-    "eslint-plugin-solid": "~0.16.0",
+    "eslint-plugin-solid": "~0.16.1",
     "filesystem-routing": "0.2.1",
     "jsdom": "^25.0.1",
     "oxlint": "~1.79.0",

--- a/solid-v2/with-sass/pnpm-lock.yaml
+++ b/solid-v2/with-sass/pnpm-lock.yaml
@@ -34,8 +34,8 @@ importers:
         specifier: ^6.6.3
         version: 6.10.0(@testing-library/dom@10.4.1)
       eslint-plugin-solid:
-        specifier: ~0.16.0
-        version: 0.16.0(eslint@10.8.1)(typescript@5.9.3)
+        specifier: ~0.16.1
+        version: 0.16.1(eslint@10.8.1)(typescript@5.9.3)
       filesystem-routing:
         specifier: 0.2.1
         version: 0.2.1(vite@8.2.1(sass@1.102.0))
@@ -1096,8 +1096,8 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-plugin-solid@0.16.0:
-    resolution: {integrity: sha512-q45VUvh3kv9ZHoVWZrep/KJFA7qqBH0khHuEEp0sCzEDuM3FtHFqK6fLWFIIIDGVQ8aFouUHROaOXVi8GgzShA==}
+  eslint-plugin-solid@0.16.1:
+    resolution: {integrity: sha512-RUd46y3Y2acT4//hxSut1UTGnDoZMWEhrplyE0cK0E3cWwvIsfui5HkG7cubQ95TntVacVHe+uYh97PSm0id4A==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       eslint: ^9.0.0 || ^10.0.0
@@ -2784,7 +2784,7 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-solid@0.16.0(eslint@10.8.1)(typescript@5.9.3):
+  eslint-plugin-solid@0.16.1(eslint@10.8.1)(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/utils': 8.67.0(eslint@10.8.1)(typescript@5.9.3)
       eslint: 10.8.1

--- a/solid-v2/with-tailwindcss/package.json
+++ b/solid-v2/with-tailwindcss/package.json
@@ -18,7 +18,7 @@
     "@solidjs/vite-plugin": "^3.0.0-next.34",
     "@tailwindcss/vite": "^4.1.13",
     "@testing-library/jest-dom": "^6.6.3",
-    "eslint-plugin-solid": "~0.16.0",
+    "eslint-plugin-solid": "~0.16.1",
     "filesystem-routing": "0.2.1",
     "jsdom": "^25.0.1",
     "oxlint": "~1.79.0",

--- a/solid-v2/with-tailwindcss/pnpm-lock.yaml
+++ b/solid-v2/with-tailwindcss/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: ^6.6.3
         version: 6.10.0(@testing-library/dom@10.4.1)
       eslint-plugin-solid:
-        specifier: ~0.16.0
-        version: 0.16.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)
+        specifier: ~0.16.1
+        version: 0.16.1(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)
       filesystem-routing:
         specifier: 0.2.1
         version: 0.2.1(vite@8.2.1(jiti@2.7.0))
@@ -1111,8 +1111,8 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-plugin-solid@0.16.0:
-    resolution: {integrity: sha512-q45VUvh3kv9ZHoVWZrep/KJFA7qqBH0khHuEEp0sCzEDuM3FtHFqK6fLWFIIIDGVQ8aFouUHROaOXVi8GgzShA==}
+  eslint-plugin-solid@0.16.1:
+    resolution: {integrity: sha512-RUd46y3Y2acT4//hxSut1UTGnDoZMWEhrplyE0cK0E3cWwvIsfui5HkG7cubQ95TntVacVHe+uYh97PSm0id4A==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       eslint: ^9.0.0 || ^10.0.0
@@ -2884,7 +2884,7 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-solid@0.16.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3):
+  eslint-plugin-solid@0.16.1(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/utils': 8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)
       eslint: 10.8.1(jiti@2.7.0)

--- a/solid-v2/with-tanstack-router/package.json
+++ b/solid-v2/with-tanstack-router/package.json
@@ -18,7 +18,7 @@
     "@solidjs/vite-plugin": "^3.0.0-next.34",
     "@tanstack/router-plugin": "1.168.27",
     "@testing-library/jest-dom": "^6.6.3",
-    "eslint-plugin-solid": "~0.16.0",
+    "eslint-plugin-solid": "~0.16.1",
     "jsdom": "^25.0.1",
     "oxlint": "~1.79.0",
     "typescript": "^5.9.2",

--- a/solid-v2/with-tanstack-router/pnpm-lock.yaml
+++ b/solid-v2/with-tanstack-router/pnpm-lock.yaml
@@ -34,8 +34,8 @@ importers:
         specifier: ^6.6.3
         version: 6.10.0(@testing-library/dom@10.4.1)
       eslint-plugin-solid:
-        specifier: ~0.16.0
-        version: 0.16.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)
+        specifier: ~0.16.1
+        version: 0.16.1(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)
       jsdom:
         specifier: ^25.0.1
         version: 25.0.1
@@ -979,8 +979,8 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-plugin-solid@0.16.0:
-    resolution: {integrity: sha512-q45VUvh3kv9ZHoVWZrep/KJFA7qqBH0khHuEEp0sCzEDuM3FtHFqK6fLWFIIIDGVQ8aFouUHROaOXVi8GgzShA==}
+  eslint-plugin-solid@0.16.1:
+    resolution: {integrity: sha512-RUd46y3Y2acT4//hxSut1UTGnDoZMWEhrplyE0cK0E3cWwvIsfui5HkG7cubQ95TntVacVHe+uYh97PSm0id4A==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       eslint: ^9.0.0 || ^10.0.0
@@ -2678,7 +2678,7 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-solid@0.16.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3):
+  eslint-plugin-solid@0.16.1(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/utils': 8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)
       eslint: 10.8.1(jiti@2.7.0)

--- a/solid-v2/with-unocss/package.json
+++ b/solid-v2/with-unocss/package.json
@@ -19,7 +19,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@unocss/preset-wind4": "^66.5.2",
     "@unocss/reset": "^66.5.2",
-    "eslint-plugin-solid": "~0.16.0",
+    "eslint-plugin-solid": "~0.16.1",
     "filesystem-routing": "0.2.1",
     "jsdom": "^25.0.1",
     "oxlint": "~1.79.0",

--- a/solid-v2/with-unocss/pnpm-lock.yaml
+++ b/solid-v2/with-unocss/pnpm-lock.yaml
@@ -40,8 +40,8 @@ importers:
         specifier: ^66.5.2
         version: 66.7.5
       eslint-plugin-solid:
-        specifier: ~0.16.0
-        version: 0.16.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)
+        specifier: ~0.16.1
+        version: 0.16.1(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)
       filesystem-routing:
         specifier: 0.2.1
         version: 0.2.1(vite@8.2.1(jiti@2.7.0))
@@ -1270,8 +1270,8 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-plugin-solid@0.16.0:
-    resolution: {integrity: sha512-q45VUvh3kv9ZHoVWZrep/KJFA7qqBH0khHuEEp0sCzEDuM3FtHFqK6fLWFIIIDGVQ8aFouUHROaOXVi8GgzShA==}
+  eslint-plugin-solid@0.16.1:
+    resolution: {integrity: sha512-RUd46y3Y2acT4//hxSut1UTGnDoZMWEhrplyE0cK0E3cWwvIsfui5HkG7cubQ95TntVacVHe+uYh97PSm0id4A==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       eslint: ^9.0.0 || ^10.0.0
@@ -3248,7 +3248,7 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-solid@0.16.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3):
+  eslint-plugin-solid@0.16.1(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/utils': 8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)
       eslint: 10.8.1(jiti@2.7.0)

--- a/solid-v2/with-vitest-browser-mode/package.json
+++ b/solid-v2/with-vitest-browser-mode/package.json
@@ -18,7 +18,7 @@
     "@solidjs/vite-plugin": "^3.0.0-next.34",
     "@testing-library/jest-dom": "^6.6.3",
     "@vitest/browser-playwright": "^4.0.0",
-    "eslint-plugin-solid": "~0.16.0",
+    "eslint-plugin-solid": "~0.16.1",
     "filesystem-routing": "0.2.1",
     "oxlint": "~1.79.0",
     "playwright": "^1.56.0",

--- a/solid-v2/with-vitest-browser-mode/pnpm-lock.yaml
+++ b/solid-v2/with-vitest-browser-mode/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: ^4.0.0
         version: 4.1.10(playwright@1.62.1)(vite@8.2.1)(vitest@4.1.10)
       eslint-plugin-solid:
-        specifier: ~0.16.0
-        version: 0.16.0(eslint@10.8.1)(typescript@5.9.3)
+        specifier: ~0.16.1
+        version: 0.16.1(eslint@10.8.1)(typescript@5.9.3)
       filesystem-routing:
         specifier: 0.2.1
         version: 0.2.1(vite@8.2.1)
@@ -946,8 +946,8 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-plugin-solid@0.16.0:
-    resolution: {integrity: sha512-q45VUvh3kv9ZHoVWZrep/KJFA7qqBH0khHuEEp0sCzEDuM3FtHFqK6fLWFIIIDGVQ8aFouUHROaOXVi8GgzShA==}
+  eslint-plugin-solid@0.16.1:
+    resolution: {integrity: sha512-RUd46y3Y2acT4//hxSut1UTGnDoZMWEhrplyE0cK0E3cWwvIsfui5HkG7cubQ95TntVacVHe+uYh97PSm0id4A==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       eslint: ^9.0.0 || ^10.0.0
@@ -2411,7 +2411,7 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-solid@0.16.0(eslint@10.8.1)(typescript@5.9.3):
+  eslint-plugin-solid@0.16.1(eslint@10.8.1)(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/utils': 8.67.0(eslint@10.8.1)(typescript@5.9.3)
       eslint: 10.8.1


### PR DESCRIPTION
## Summary

- Raises the `eslint-plugin-solid` floor from `~0.16.0` to `~0.16.1` in the 10 solid-v2 templates and refreshes their lockfiles, so scaffolded projects get the 0.16.1 precision fixes immediately (the reactivity false-positive pass, stale-capture detection, `no-destructure` component identification, v2-aware duplicate-`class` guidance) instead of the lockfile-pinned 0.16.0.
- `solid-start-v2/with-authjs` is untouched: it's a Solid 1.x template on eslint 8 / plugin 0.14.

## Test plan

- [x] All 10 lockfiles resolve `eslint-plugin-solid@0.16.1`; diffs touch only the plugin entries
- [x] `pnpm run lint` clean on the basic template with 0.16.1 installed

Made with [Cursor](https://cursor.com)