### PR TITLE
solid-v2: bump @solidjs/router to 2.0.0-next.18

### DIFF
--- a/solid-v2/basic/package.json
+++ b/solid-v2/basic/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@solidjs/meta": "^1.0.0-next.2",
-    "@solidjs/router": "^2.0.0-next.17",
+    "@solidjs/router": "^2.0.0-next.18",
     "@solidjs/web": "^2.0.0-rc.3",
     "solid-js": "^2.0.0-rc.3"
   }

--- a/solid-v2/basic/pnpm-lock.yaml
+++ b/solid-v2/basic/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.0.0-next.2
         version: 1.0.0-next.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/router':
-        specifier: ^2.0.0-next.17
-        version: 2.0.0-next.17(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
+        specifier: ^2.0.0-next.18
+        version: 2.0.0-next.18(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/web':
         specifier: ^2.0.0-rc.3
         version: 2.0.0-rc.3(solid-js@2.0.0-rc.3)
@@ -684,11 +684,11 @@ packages:
       '@solidjs/web': ^2.0.0-rc.0
       solid-js: ^2.0.0-rc.0
 
-  '@solidjs/router@2.0.0-next.17':
-    resolution: {integrity: sha512-LchYm3IZ3Y7vGPh/Jx6X8UjpBirQrz9ZoRQkgRpdz8A9C7eTiRXY326pJDcoYDXn7FzYtFpRCwsfBMxRDsFo6A==}
+  '@solidjs/router@2.0.0-next.18':
+    resolution: {integrity: sha512-DQ58djANKYi4HZfE9J7vN9kAtAH/eKYkUj61cezfDrBae3A/cgthgdjQS9C8pNGtNeST6aA8GNhcFYKlUWn+zA==}
     peerDependencies:
-      '@solidjs/web': ^2.0.0-rc.1
-      solid-js: ^2.0.0-rc.1
+      '@solidjs/web': ^2.0.0-rc.3
+      solid-js: ^2.0.0-rc.3
 
   '@solidjs/signals@2.0.0-rc.3':
     resolution: {integrity: sha512-/yPhTf3xS1FRR4MX8kTYCd4MjsFxzwkO+KyOTfbu35lTEiaJ4Fxy+JL91XonDzt31GV1mYaZ9CGD2TQIzvXuNA==}
@@ -2288,7 +2288,7 @@ snapshots:
       '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       solid-js: 2.0.0-rc.3
 
-  '@solidjs/router@2.0.0-next.17(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
+  '@solidjs/router@2.0.0-next.18(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
     dependencies:
       '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       solid-js: 2.0.0-rc.3

--- a/solid-v2/fullstack/package.json
+++ b/solid-v2/fullstack/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@remix-run/cookie": "^0.5.4",
     "@solidjs/meta": "^1.0.0-next.2",
-    "@solidjs/router": "^2.0.0-next.17",
+    "@solidjs/router": "^2.0.0-next.18",
     "@solidjs/web": "^2.0.0-rc.3",
     "solid-js": "^2.0.0-rc.3",
     "valibot": "^1.4.2"

--- a/solid-v2/fullstack/pnpm-lock.yaml
+++ b/solid-v2/fullstack/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^1.0.0-next.2
         version: 1.0.0-next.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/router':
-        specifier: ^2.0.0-next.17
-        version: 2.0.0-next.17(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
+        specifier: ^2.0.0-next.18
+        version: 2.0.0-next.18(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/web':
         specifier: ^2.0.0-rc.3
         version: 2.0.0-rc.3(solid-js@2.0.0-rc.3)
@@ -699,11 +699,11 @@ packages:
       '@solidjs/web': ^2.0.0-rc.0
       solid-js: ^2.0.0-rc.0
 
-  '@solidjs/router@2.0.0-next.17':
-    resolution: {integrity: sha512-LchYm3IZ3Y7vGPh/Jx6X8UjpBirQrz9ZoRQkgRpdz8A9C7eTiRXY326pJDcoYDXn7FzYtFpRCwsfBMxRDsFo6A==}
+  '@solidjs/router@2.0.0-next.18':
+    resolution: {integrity: sha512-DQ58djANKYi4HZfE9J7vN9kAtAH/eKYkUj61cezfDrBae3A/cgthgdjQS9C8pNGtNeST6aA8GNhcFYKlUWn+zA==}
     peerDependencies:
-      '@solidjs/web': ^2.0.0-rc.1
-      solid-js: ^2.0.0-rc.1
+      '@solidjs/web': ^2.0.0-rc.3
+      solid-js: ^2.0.0-rc.3
 
   '@solidjs/signals@2.0.0-rc.3':
     resolution: {integrity: sha512-/yPhTf3xS1FRR4MX8kTYCd4MjsFxzwkO+KyOTfbu35lTEiaJ4Fxy+JL91XonDzt31GV1mYaZ9CGD2TQIzvXuNA==}
@@ -2323,7 +2323,7 @@ snapshots:
       '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       solid-js: 2.0.0-rc.3
 
-  '@solidjs/router@2.0.0-next.17(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
+  '@solidjs/router@2.0.0-next.18(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
     dependencies:
       '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       solid-js: 2.0.0-rc.3

--- a/solid-v2/with-bootstrap/package.json
+++ b/solid-v2/with-bootstrap/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@solidjs/meta": "^1.0.0-next.2",
-    "@solidjs/router": "^2.0.0-next.17",
+    "@solidjs/router": "^2.0.0-next.18",
     "@solidjs/web": "^2.0.0-rc.3",
     "bootstrap": "^5.3.3",
     "solid-js": "^2.0.0-rc.3"

--- a/solid-v2/with-bootstrap/pnpm-lock.yaml
+++ b/solid-v2/with-bootstrap/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.0.0-next.2
         version: 1.0.0-next.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/router':
-        specifier: ^2.0.0-next.17
-        version: 2.0.0-next.17(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
+        specifier: ^2.0.0-next.18
+        version: 2.0.0-next.18(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/web':
         specifier: ^2.0.0-rc.3
         version: 2.0.0-rc.3(solid-js@2.0.0-rc.3)
@@ -690,11 +690,11 @@ packages:
       '@solidjs/web': ^2.0.0-rc.0
       solid-js: ^2.0.0-rc.0
 
-  '@solidjs/router@2.0.0-next.17':
-    resolution: {integrity: sha512-LchYm3IZ3Y7vGPh/Jx6X8UjpBirQrz9ZoRQkgRpdz8A9C7eTiRXY326pJDcoYDXn7FzYtFpRCwsfBMxRDsFo6A==}
+  '@solidjs/router@2.0.0-next.18':
+    resolution: {integrity: sha512-DQ58djANKYi4HZfE9J7vN9kAtAH/eKYkUj61cezfDrBae3A/cgthgdjQS9C8pNGtNeST6aA8GNhcFYKlUWn+zA==}
     peerDependencies:
-      '@solidjs/web': ^2.0.0-rc.1
-      solid-js: ^2.0.0-rc.1
+      '@solidjs/web': ^2.0.0-rc.3
+      solid-js: ^2.0.0-rc.3
 
   '@solidjs/signals@2.0.0-rc.3':
     resolution: {integrity: sha512-/yPhTf3xS1FRR4MX8kTYCd4MjsFxzwkO+KyOTfbu35lTEiaJ4Fxy+JL91XonDzt31GV1mYaZ9CGD2TQIzvXuNA==}
@@ -2301,7 +2301,7 @@ snapshots:
       '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       solid-js: 2.0.0-rc.3
 
-  '@solidjs/router@2.0.0-next.17(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
+  '@solidjs/router@2.0.0-next.18(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
     dependencies:
       '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       solid-js: 2.0.0-rc.3

--- a/solid-v2/with-sass/package.json
+++ b/solid-v2/with-sass/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@solidjs/meta": "^1.0.0-next.2",
-    "@solidjs/router": "^2.0.0-next.17",
+    "@solidjs/router": "^2.0.0-next.18",
     "@solidjs/web": "^2.0.0-rc.3",
     "solid-js": "^2.0.0-rc.3"
   }

--- a/solid-v2/with-sass/pnpm-lock.yaml
+++ b/solid-v2/with-sass/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.0.0-next.2
         version: 1.0.0-next.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/router':
-        specifier: ^2.0.0-next.17
-        version: 2.0.0-next.17(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
+        specifier: ^2.0.0-next.18
+        version: 2.0.0-next.18(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/web':
         specifier: ^2.0.0-rc.3
         version: 2.0.0-rc.3(solid-js@2.0.0-rc.3)
@@ -769,11 +769,11 @@ packages:
       '@solidjs/web': ^2.0.0-rc.0
       solid-js: ^2.0.0-rc.0
 
-  '@solidjs/router@2.0.0-next.17':
-    resolution: {integrity: sha512-LchYm3IZ3Y7vGPh/Jx6X8UjpBirQrz9ZoRQkgRpdz8A9C7eTiRXY326pJDcoYDXn7FzYtFpRCwsfBMxRDsFo6A==}
+  '@solidjs/router@2.0.0-next.18':
+    resolution: {integrity: sha512-DQ58djANKYi4HZfE9J7vN9kAtAH/eKYkUj61cezfDrBae3A/cgthgdjQS9C8pNGtNeST6aA8GNhcFYKlUWn+zA==}
     peerDependencies:
-      '@solidjs/web': ^2.0.0-rc.1
-      solid-js: ^2.0.0-rc.1
+      '@solidjs/web': ^2.0.0-rc.3
+      solid-js: ^2.0.0-rc.3
 
   '@solidjs/signals@2.0.0-rc.3':
     resolution: {integrity: sha512-/yPhTf3xS1FRR4MX8kTYCd4MjsFxzwkO+KyOTfbu35lTEiaJ4Fxy+JL91XonDzt31GV1mYaZ9CGD2TQIzvXuNA==}
@@ -2449,7 +2449,7 @@ snapshots:
       '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       solid-js: 2.0.0-rc.3
 
-  '@solidjs/router@2.0.0-next.17(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
+  '@solidjs/router@2.0.0-next.18(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
     dependencies:
       '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       solid-js: 2.0.0-rc.3

--- a/solid-v2/with-tailwindcss/package.json
+++ b/solid-v2/with-tailwindcss/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@solidjs/meta": "^1.0.0-next.2",
-    "@solidjs/router": "^2.0.0-next.17",
+    "@solidjs/router": "^2.0.0-next.18",
     "@solidjs/web": "^2.0.0-rc.3",
     "solid-js": "^2.0.0-rc.3"
   }

--- a/solid-v2/with-tailwindcss/pnpm-lock.yaml
+++ b/solid-v2/with-tailwindcss/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.0.0-next.2
         version: 1.0.0-next.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/router':
-        specifier: ^2.0.0-next.17
-        version: 2.0.0-next.17(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
+        specifier: ^2.0.0-next.18
+        version: 2.0.0-next.18(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/web':
         specifier: ^2.0.0-rc.3
         version: 2.0.0-rc.3(solid-js@2.0.0-rc.3)
@@ -690,11 +690,11 @@ packages:
       '@solidjs/web': ^2.0.0-rc.0
       solid-js: ^2.0.0-rc.0
 
-  '@solidjs/router@2.0.0-next.17':
-    resolution: {integrity: sha512-LchYm3IZ3Y7vGPh/Jx6X8UjpBirQrz9ZoRQkgRpdz8A9C7eTiRXY326pJDcoYDXn7FzYtFpRCwsfBMxRDsFo6A==}
+  '@solidjs/router@2.0.0-next.18':
+    resolution: {integrity: sha512-DQ58djANKYi4HZfE9J7vN9kAtAH/eKYkUj61cezfDrBae3A/cgthgdjQS9C8pNGtNeST6aA8GNhcFYKlUWn+zA==}
     peerDependencies:
-      '@solidjs/web': ^2.0.0-rc.1
-      solid-js: ^2.0.0-rc.1
+      '@solidjs/web': ^2.0.0-rc.3
+      solid-js: ^2.0.0-rc.3
 
   '@solidjs/signals@2.0.0-rc.3':
     resolution: {integrity: sha512-/yPhTf3xS1FRR4MX8kTYCd4MjsFxzwkO+KyOTfbu35lTEiaJ4Fxy+JL91XonDzt31GV1mYaZ9CGD2TQIzvXuNA==}
@@ -2480,7 +2480,7 @@ snapshots:
       '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       solid-js: 2.0.0-rc.3
 
-  '@solidjs/router@2.0.0-next.17(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
+  '@solidjs/router@2.0.0-next.18(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
     dependencies:
       '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       solid-js: 2.0.0-rc.3

--- a/solid-v2/with-unocss/package.json
+++ b/solid-v2/with-unocss/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@solidjs/meta": "^1.0.0-next.2",
-    "@solidjs/router": "^2.0.0-next.17",
+    "@solidjs/router": "^2.0.0-next.18",
     "@solidjs/web": "^2.0.0-rc.3",
     "solid-js": "^2.0.0-rc.3"
   }

--- a/solid-v2/with-unocss/pnpm-lock.yaml
+++ b/solid-v2/with-unocss/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.0.0-next.2
         version: 1.0.0-next.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/router':
-        specifier: ^2.0.0-next.17
-        version: 2.0.0-next.17(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
+        specifier: ^2.0.0-next.18
+        version: 2.0.0-next.18(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/web':
         specifier: ^2.0.0-rc.3
         version: 2.0.0-rc.3(solid-js@2.0.0-rc.3)
@@ -847,11 +847,11 @@ packages:
       '@solidjs/web': ^2.0.0-rc.0
       solid-js: ^2.0.0-rc.0
 
-  '@solidjs/router@2.0.0-next.17':
-    resolution: {integrity: sha512-LchYm3IZ3Y7vGPh/Jx6X8UjpBirQrz9ZoRQkgRpdz8A9C7eTiRXY326pJDcoYDXn7FzYtFpRCwsfBMxRDsFo6A==}
+  '@solidjs/router@2.0.0-next.18':
+    resolution: {integrity: sha512-DQ58djANKYi4HZfE9J7vN9kAtAH/eKYkUj61cezfDrBae3A/cgthgdjQS9C8pNGtNeST6aA8GNhcFYKlUWn+zA==}
     peerDependencies:
-      '@solidjs/web': ^2.0.0-rc.1
-      solid-js: ^2.0.0-rc.1
+      '@solidjs/web': ^2.0.0-rc.3
+      solid-js: ^2.0.0-rc.3
 
   '@solidjs/signals@2.0.0-rc.3':
     resolution: {integrity: sha512-/yPhTf3xS1FRR4MX8kTYCd4MjsFxzwkO+KyOTfbu35lTEiaJ4Fxy+JL91XonDzt31GV1mYaZ9CGD2TQIzvXuNA==}
@@ -2763,7 +2763,7 @@ snapshots:
       '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       solid-js: 2.0.0-rc.3
 
-  '@solidjs/router@2.0.0-next.17(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
+  '@solidjs/router@2.0.0-next.18(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
     dependencies:
       '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       solid-js: 2.0.0-rc.3

--- a/solid-v2/with-vitest-browser-mode/package.json
+++ b/solid-v2/with-vitest-browser-mode/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@solidjs/meta": "^1.0.0-next.2",
-    "@solidjs/router": "^2.0.0-next.17",
+    "@solidjs/router": "^2.0.0-next.18",
     "@solidjs/web": "^2.0.0-rc.3",
     "solid-js": "^2.0.0-rc.3"
   }

--- a/solid-v2/with-vitest-browser-mode/pnpm-lock.yaml
+++ b/solid-v2/with-vitest-browser-mode/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.0.0-next.2
         version: 1.0.0-next.2(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/router':
-        specifier: ^2.0.0-next.17
-        version: 2.0.0-next.17(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
+        specifier: ^2.0.0-next.18
+        version: 2.0.0-next.18(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       '@solidjs/web':
         specifier: ^2.0.0-rc.3
         version: 2.0.0-rc.3(solid-js@2.0.0-rc.3)
@@ -662,11 +662,11 @@ packages:
       '@solidjs/web': ^2.0.0-rc.0
       solid-js: ^2.0.0-rc.0
 
-  '@solidjs/router@2.0.0-next.17':
-    resolution: {integrity: sha512-LchYm3IZ3Y7vGPh/Jx6X8UjpBirQrz9ZoRQkgRpdz8A9C7eTiRXY326pJDcoYDXn7FzYtFpRCwsfBMxRDsFo6A==}
+  '@solidjs/router@2.0.0-next.18':
+    resolution: {integrity: sha512-DQ58djANKYi4HZfE9J7vN9kAtAH/eKYkUj61cezfDrBae3A/cgthgdjQS9C8pNGtNeST6aA8GNhcFYKlUWn+zA==}
     peerDependencies:
-      '@solidjs/web': ^2.0.0-rc.1
-      solid-js: ^2.0.0-rc.1
+      '@solidjs/web': ^2.0.0-rc.3
+      solid-js: ^2.0.0-rc.3
 
   '@solidjs/signals@2.0.0-rc.3':
     resolution: {integrity: sha512-/yPhTf3xS1FRR4MX8kTYCd4MjsFxzwkO+KyOTfbu35lTEiaJ4Fxy+JL91XonDzt31GV1mYaZ9CGD2TQIzvXuNA==}
@@ -2098,7 +2098,7 @@ snapshots:
       '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       solid-js: 2.0.0-rc.3
 
-  '@solidjs/router@2.0.0-next.17(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
+  '@solidjs/router@2.0.0-next.18(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
     dependencies:
       '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       solid-js: 2.0.0-rc.3


### PR DESCRIPTION
## Summary

- Bumps `@solidjs/router` from `^2.0.0-next.17` to `^2.0.0-next.18` (published 2026-08-26) in the 7 solid-v2 templates that use it, refreshing their lockfiles so scaffolds resolve next.18 immediately.

## Test plan

- [x] All 7 lockfiles resolve `@solidjs/router@2.0.0-next.18`; diffs touch only the router entries
- [x] `basic` template builds (client + server) on next.18

Made with [Cursor](https://cursor.com)