### PR TITLE
solid-v2: dim user pages with isPending during navigation

### DIFF
--- a/solid-v2/basic/src/routes/users/[id].tsx
+++ b/solid-v2/basic/src/routes/users/[id].tsx
@@ -1,7 +1,7 @@
 import { Title } from '@solidjs/meta';
 import { query, type RouteDefinition, type RouteProps } from '@solidjs/router';
 import { getRequestEvent } from '@solidjs/web';
-import { createMemo } from 'solid-js';
+import { createMemo, isPending } from 'solid-js';
 import { paths } from '../../router';
 
 // Async data loading: a query (cached per key) read through a memo — the
@@ -26,7 +26,7 @@ export default function User(props: RouteProps<'/users/:id'>) {
   const user = createMemo(() => getUser(props.params.id));
 
   return (
-    <section>
+    <section style={{ opacity: isPending(user) ? 0.5 : 1 }}>
       <Title>{`User ${props.params.id} - Solid App`}</Title>
       <h2>{user().name}</h2>
       <p>{user().title}</p>

--- a/solid-v2/fullstack-tanstack/src/lib/users.ts
+++ b/solid-v2/fullstack-tanstack/src/lib/users.ts
@@ -24,7 +24,6 @@ export const getUsers = GET(async () => {
 
 export const getUser = GET(async (id: string) => {
   'use server';
-  await new Promise((resolve) => setTimeout(resolve, 1000));
   return findUser(id) ?? { name: 'Unknown', title: 'No such user' };
 });
 

--- a/solid-v2/fullstack-tanstack/src/routes/users.$id.tsx
+++ b/solid-v2/fullstack-tanstack/src/routes/users.$id.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery } from '@tanstack/solid-query';
 import { createFileRoute } from '@tanstack/solid-router';
-import { Show } from 'solid-js';
+import { isPending, Show } from 'solid-js';
 
 import { currentUserQuery, prefetch, userQuery } from '../lib/queries';
 import { renameUser } from '../lib/users';
@@ -35,7 +35,7 @@ function UserPage() {
   }));
 
   return (
-    <section>
+    <section style={{ opacity: isPending(() => user.data) ? 0.5 : 1 }}>
       {/* Reads suspend to the surrounding boundary until the query settles —
           no loading guard, same shape as the plain fullstack template. */}
       <h2>{user.data.name}</h2>

--- a/solid-v2/fullstack/src/routes/users/[id].tsx
+++ b/solid-v2/fullstack/src/routes/users/[id].tsx
@@ -1,6 +1,6 @@
 import { Title } from '@solidjs/meta';
 import { type RouteDefinition, type RouteProps } from '@solidjs/router';
-import { Show, createMemo } from 'solid-js';
+import { Show, createMemo, isPending } from 'solid-js';
 
 import { getCurrentUser, getUser, renameUser } from '../../lib/users';
 
@@ -21,7 +21,7 @@ export default function User(props: RouteProps<'/users/:id'>) {
   const me = createMemo(() => getCurrentUser());
 
   return (
-    <section>
+    <section style={{ opacity: isPending(user) ? 0.5 : 1 }}>
       <Title>{`User ${props.params.id} - Solid App`}</Title>
       <h2>{user().name}</h2>
       <p>{user().title}</p>


### PR DESCRIPTION
Applies the v2 pending-navigation pattern to the user detail pages in `basic`, `fullstack`, and `fullstack-tanstack`: dim the section to 0.5 opacity with `isPending` while a navigation refreshes the async user data, and in `fullstack-tanstack` also drop the artificial 1s delay in the `getUser` server function.

Originally this PR also carried the solid/tanstack prerelease bumps, but those landed directly on main (along with the typed-argument mutation reshape), so it's been rebased down to just the UI changes on top of that shape.

Verified against current main: `pnpm run build` succeeds in all three templates and the `fullstack-tanstack` vitest suite passes (10 tests).

(The earlier note here about `useMutation`'s `STRICT_READ_UNTRACKED` warning is resolved upstream via TanStack/query#11325, which flight-scopes the mutation-cache subscription.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)