### PR TITLE
solid-v2: require @solidjs/testing-library 1.0.0-beta.3 so installs resolve on Solid 2 prereleases

### DIFF
--- a/PORTING.md
+++ b/PORTING.md
@@ -21,7 +21,7 @@ each "blocked" row says exactly what to check before porting.
 
 Resolved since the original audit (kept here so the history reads right):
 
-- `@solidjs/testing-library` — unblocked: `1.0.0-beta.2` targets Solid 2 and ships in
+- `@solidjs/testing-library` — unblocked: `1.0.0-beta.3` targets Solid 2 and ships in
   `basic`'s test floor. Advance the pin when a stable lands.
 - TanStack Router / Query — unblocked: `with-tanstack-router` and `fullstack-tanstack`
   shipped on their Solid 2 betas.

--- a/solid-v2/basic/package.json
+++ b/solid-v2/basic/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "devDependencies": {
     "@solidjs/diagnostics": "^2.0.0-rc.6",
-    "@solidjs/testing-library": "^1.0.0-beta.2",
+    "@solidjs/testing-library": "^1.0.0-beta.3",
     "@solidjs/vite-plugin": "^3.0.0-next.38",
     "@testing-library/jest-dom": "^6.6.3",
     "eslint-plugin-solid": "~0.17.0",

--- a/solid-v2/basic/pnpm-lock.yaml
+++ b/solid-v2/basic/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         specifier: ^2.0.0-rc.6
         version: 2.0.0-rc.6(vitest@4.1.11(jsdom@25.0.1)(vite@8.2.2))
       '@solidjs/testing-library':
-        specifier: ^1.0.0-beta.2
+        specifier: ^1.0.0-beta.3
         version: 1.0.0-beta.3(@solidjs/web@2.0.0-rc.6(solid-js@2.0.0-rc.6))(solid-js@2.0.0-rc.6)
       '@solidjs/vite-plugin':
         specifier: ^3.0.0-next.38

--- a/solid-v2/fullstack-tanstack/package.json
+++ b/solid-v2/fullstack-tanstack/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "devDependencies": {
     "@solidjs/diagnostics": "^2.0.0-rc.6",
-    "@solidjs/testing-library": "^1.0.0-beta.2",
+    "@solidjs/testing-library": "^1.0.0-beta.3",
     "@solidjs/vite-plugin": "^3.0.0-next.38",
     "@tanstack/router-plugin": "1.168.35",
     "@testing-library/jest-dom": "^6.6.3",

--- a/solid-v2/fullstack-tanstack/pnpm-lock.yaml
+++ b/solid-v2/fullstack-tanstack/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         specifier: ^2.0.0-rc.6
         version: 2.0.0-rc.6(vitest@4.1.11(@types/node@26.4.1)(jsdom@25.0.1)(vite@8.2.2(@types/node@26.4.1)(jiti@2.7.0)))
       '@solidjs/testing-library':
-        specifier: ^1.0.0-beta.2
+        specifier: ^1.0.0-beta.3
         version: 1.0.0-beta.3(@solidjs/web@2.0.0-rc.6(solid-js@2.0.0-rc.6))(solid-js@2.0.0-rc.6)
       '@solidjs/vite-plugin':
         specifier: ^3.0.0-next.38

--- a/solid-v2/fullstack/package.json
+++ b/solid-v2/fullstack/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "devDependencies": {
     "@solidjs/diagnostics": "^2.0.0-rc.6",
-    "@solidjs/testing-library": "^1.0.0-beta.2",
+    "@solidjs/testing-library": "^1.0.0-beta.3",
     "@solidjs/vite-plugin": "^3.0.0-next.38",
     "@testing-library/jest-dom": "^6.6.3",
     "@types/node": "^26.2.0",

--- a/solid-v2/fullstack/pnpm-lock.yaml
+++ b/solid-v2/fullstack/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         specifier: ^2.0.0-rc.6
         version: 2.0.0-rc.6(vitest@4.1.11(@types/node@26.4.1)(jsdom@25.0.1)(vite@8.2.2(@types/node@26.4.1)))
       '@solidjs/testing-library':
-        specifier: ^1.0.0-beta.2
+        specifier: ^1.0.0-beta.3
         version: 1.0.0-beta.3(@solidjs/web@2.0.0-rc.6(solid-js@2.0.0-rc.6))(solid-js@2.0.0-rc.6)
       '@solidjs/vite-plugin':
         specifier: ^3.0.0-next.38

--- a/solid-v2/with-bootstrap/package.json
+++ b/solid-v2/with-bootstrap/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "devDependencies": {
     "@solidjs/diagnostics": "^2.0.0-rc.6",
-    "@solidjs/testing-library": "^1.0.0-beta.2",
+    "@solidjs/testing-library": "^1.0.0-beta.3",
     "@solidjs/vite-plugin": "^3.0.0-next.38",
     "@testing-library/jest-dom": "^6.6.3",
     "eslint-plugin-solid": "~0.17.0",

--- a/solid-v2/with-bootstrap/pnpm-lock.yaml
+++ b/solid-v2/with-bootstrap/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         specifier: ^2.0.0-rc.6
         version: 2.0.0-rc.6(vitest@4.1.11(jsdom@25.0.1)(vite@8.2.2))
       '@solidjs/testing-library':
-        specifier: ^1.0.0-beta.2
+        specifier: ^1.0.0-beta.3
         version: 1.0.0-beta.3(@solidjs/web@2.0.0-rc.6(solid-js@2.0.0-rc.6))(solid-js@2.0.0-rc.6)
       '@solidjs/vite-plugin':
         specifier: ^3.0.0-next.38

--- a/solid-v2/with-sass/package.json
+++ b/solid-v2/with-sass/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "devDependencies": {
     "@solidjs/diagnostics": "^2.0.0-rc.6",
-    "@solidjs/testing-library": "^1.0.0-beta.2",
+    "@solidjs/testing-library": "^1.0.0-beta.3",
     "@solidjs/vite-plugin": "^3.0.0-next.38",
     "@testing-library/jest-dom": "^6.6.3",
     "eslint-plugin-solid": "~0.17.0",

--- a/solid-v2/with-sass/pnpm-lock.yaml
+++ b/solid-v2/with-sass/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         specifier: ^2.0.0-rc.6
         version: 2.0.0-rc.6(vitest@4.1.11(jsdom@25.0.1)(vite@8.2.2(sass@1.103.1)))
       '@solidjs/testing-library':
-        specifier: ^1.0.0-beta.2
+        specifier: ^1.0.0-beta.3
         version: 1.0.0-beta.3(@solidjs/web@2.0.0-rc.6(solid-js@2.0.0-rc.6))(solid-js@2.0.0-rc.6)
       '@solidjs/vite-plugin':
         specifier: ^3.0.0-next.38

--- a/solid-v2/with-tailwindcss/package.json
+++ b/solid-v2/with-tailwindcss/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "devDependencies": {
     "@solidjs/diagnostics": "^2.0.0-rc.6",
-    "@solidjs/testing-library": "^1.0.0-beta.2",
+    "@solidjs/testing-library": "^1.0.0-beta.3",
     "@solidjs/vite-plugin": "^3.0.0-next.38",
     "@tailwindcss/vite": "^4.1.13",
     "@testing-library/jest-dom": "^6.6.3",

--- a/solid-v2/with-tailwindcss/pnpm-lock.yaml
+++ b/solid-v2/with-tailwindcss/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         specifier: ^2.0.0-rc.6
         version: 2.0.0-rc.6(vitest@4.1.11(jsdom@25.0.1)(vite@8.2.2(jiti@2.7.0)))
       '@solidjs/testing-library':
-        specifier: ^1.0.0-beta.2
+        specifier: ^1.0.0-beta.3
         version: 1.0.0-beta.3(@solidjs/web@2.0.0-rc.6(solid-js@2.0.0-rc.6))(solid-js@2.0.0-rc.6)
       '@solidjs/vite-plugin':
         specifier: ^3.0.0-next.38

--- a/solid-v2/with-tanstack-router/package.json
+++ b/solid-v2/with-tanstack-router/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "devDependencies": {
     "@solidjs/diagnostics": "^2.0.0-rc.6",
-    "@solidjs/testing-library": "^1.0.0-beta.2",
+    "@solidjs/testing-library": "^1.0.0-beta.3",
     "@solidjs/vite-plugin": "^3.0.0-next.38",
     "@tanstack/router-plugin": "1.168.35",
     "@testing-library/jest-dom": "^6.6.3",

--- a/solid-v2/with-tanstack-router/pnpm-lock.yaml
+++ b/solid-v2/with-tanstack-router/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         specifier: ^2.0.0-rc.6
         version: 2.0.0-rc.6(vitest@4.1.11(jsdom@25.0.1)(vite@8.2.2(jiti@2.7.0)))
       '@solidjs/testing-library':
-        specifier: ^1.0.0-beta.2
+        specifier: ^1.0.0-beta.3
         version: 1.0.0-beta.3(@solidjs/web@2.0.0-rc.6(solid-js@2.0.0-rc.6))(solid-js@2.0.0-rc.6)
       '@solidjs/vite-plugin':
         specifier: ^3.0.0-next.38

--- a/solid-v2/with-tsrx/package.json
+++ b/solid-v2/with-tsrx/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "devDependencies": {
     "@solidjs/diagnostics": "^2.0.0-rc.6",
-    "@solidjs/testing-library": "^1.0.0-beta.2",
+    "@solidjs/testing-library": "^1.0.0-beta.3",
     "@solidjs/vite-plugin": "^3.0.0-next.38",
     "@testing-library/jest-dom": "^6.6.3",
     "@tsrx/oxc": "^0.9.0",

--- a/solid-v2/with-tsrx/pnpm-lock.yaml
+++ b/solid-v2/with-tsrx/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         specifier: ^2.0.0-rc.6
         version: 2.0.0-rc.6(vitest@4.1.11(jsdom@25.0.1)(vite@8.2.2))
       '@solidjs/testing-library':
-        specifier: ^1.0.0-beta.2
+        specifier: ^1.0.0-beta.3
         version: 1.0.0-beta.3(@solidjs/web@2.0.0-rc.6(solid-js@2.0.0-rc.6))(solid-js@2.0.0-rc.6)
       '@solidjs/vite-plugin':
         specifier: ^3.0.0-next.38

--- a/solid-v2/with-unocss/package.json
+++ b/solid-v2/with-unocss/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "devDependencies": {
     "@solidjs/diagnostics": "^2.0.0-rc.6",
-    "@solidjs/testing-library": "^1.0.0-beta.2",
+    "@solidjs/testing-library": "^1.0.0-beta.3",
     "@solidjs/vite-plugin": "^3.0.0-next.38",
     "@testing-library/jest-dom": "^6.6.3",
     "@unocss/preset-wind4": "^66.5.2",

--- a/solid-v2/with-unocss/pnpm-lock.yaml
+++ b/solid-v2/with-unocss/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         specifier: ^2.0.0-rc.6
         version: 2.0.0-rc.6(vitest@4.1.11(jsdom@25.0.1)(vite@8.2.2(jiti@2.7.0)))
       '@solidjs/testing-library':
-        specifier: ^1.0.0-beta.2
+        specifier: ^1.0.0-beta.3
         version: 1.0.0-beta.3(@solidjs/web@2.0.0-rc.6(solid-js@2.0.0-rc.6))(solid-js@2.0.0-rc.6)
       '@solidjs/vite-plugin':
         specifier: ^3.0.0-next.38

--- a/solid-v2/with-vitest-browser-mode/package.json
+++ b/solid-v2/with-vitest-browser-mode/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "devDependencies": {
     "@solidjs/diagnostics": "^2.0.0-rc.6",
-    "@solidjs/testing-library": "^1.0.0-beta.2",
+    "@solidjs/testing-library": "^1.0.0-beta.3",
     "@solidjs/vite-plugin": "^3.0.0-next.38",
     "@testing-library/jest-dom": "^6.6.3",
     "@vitest/browser-playwright": "^4.0.0",

--- a/solid-v2/with-vitest-browser-mode/pnpm-lock.yaml
+++ b/solid-v2/with-vitest-browser-mode/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         specifier: ^2.0.0-rc.6
         version: 2.0.0-rc.6(vitest@4.1.11)
       '@solidjs/testing-library':
-        specifier: ^1.0.0-beta.2
+        specifier: ^1.0.0-beta.3
         version: 1.0.0-beta.3(@solidjs/web@2.0.0-rc.6(solid-js@2.0.0-rc.6))(solid-js@2.0.0-rc.6)
       '@solidjs/vite-plugin':
         specifier: ^3.0.0-next.38


### PR DESCRIPTION
## Summary

- Raise the `@solidjs/testing-library` floor from `^1.0.0-beta.2` to `^1.0.0-beta.3` in every solid-v2 template with a test setup: basic, fullstack, fullstack-tanstack, with-bootstrap, with-sass, with-tailwindcss, with-tanstack-router, with-tsrx, with-unocss, with-vitest-browser-mode.
- Move each template's `pnpm-lock.yaml` importer specifier to match. The lockfiles on `main` were regenerated after beta.3 shipped and already resolve it, so each lockfile diff is the specifier line only.
- Update the PORTING.md note that records the unblocked pin.

beta.2 declared its `solid-js` / `@solidjs/web` peers as `>=2.0.0`, which npm does not satisfy with a `2.0.0-rc.x` prerelease, so a fresh `npm install` of a generated project failed with `ERESOLVE unable to resolve dependency tree` (solidjs/solid#3212). beta.3 (solidjs/solid-testing-library#76) uses `>=2.0.0-0`, which admits the Solid 2 prereleases. Now that beta.3 is published, npm already picks it for the old `^1.0.0-beta.2` range; raising the floor makes the requirement explicit and rules out beta.2 for resolvers that do not take the newest match (pnpm under a `minimumReleaseAge` policy, offline caches). This is the template rollout step called out in the issue thread.

Refs solidjs/solid#3212.

## Verification

- Fresh `npm install` (npm 11.6.2) of `basic` copied without its lockfile resolves `@solidjs/testing-library@1.0.0-beta.3` beside `solid-js@2.0.0-rc.6` with no ERESOLVE, and `vitest run` passes.
- `pnpm install --frozen-lockfile` in `basic` from the updated lockfile, then `vitest run`: passing.
- All ten lockfiles pass `--frozen-lockfile` under pnpm 10.14.0, the repo's declared `packageManager`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
