### PR TITLE
solid-v2/with-tsrx: mark .tsrx files as TSX for GitHub linguist

### DIFF
--- a/solid-v2/with-tsrx/.gitattributes
+++ b/solid-v2/with-tsrx/.gitattributes
@@ -1,0 +1,1 @@
+*.tsrx linguist-language=TSX


### PR DESCRIPTION
## Summary

- Add `solid-v2/with-tsrx/.gitattributes` with a single rule, `*.tsrx linguist-language=TSX`.
- GitHub's linguist has no entry for the `.tsrx` extension, so the template's eight `.tsrx` modules (`src/App.tsrx`, `src/Document.tsrx`, the components, and every route module) currently render as plain text on GitHub and are excluded from the repo's language stats. With the attribute, GitHub highlights and classifies them as TSX.
- The file is scoped to the template directory, so it also ships with every project scaffolded from `with-tsrx` (create-solid copies the template's dotfiles alongside `.gitignore` and `.vscode/`), giving generated repos the same treatment.

## Verification

- `git check-attr linguist-language solid-v2/with-tsrx/src/App.tsrx` and `src/routes/index.tsrx` both resolve to `TSX`; `src/App.css` stays `unspecified`.
- No other template in the repo has a `.gitattributes`, so nothing else is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
