### PR TITLE
solid-v2/fullstack-tanstack: scope single-flight collection with declared keys

### DIFF
--- a/solid-v2/fullstack-tanstack/package.json
+++ b/solid-v2/fullstack-tanstack/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@remix-run/cookie": "^0.5.4",
     "@solidjs/web": "^2.0.0-rc.6",
-    "@tanstack/solid-query": "^6.0.0-rc.2",
+    "@tanstack/solid-query": "^6.0.0-rc.3",
     "@tanstack/solid-router": "^2.0.0-rc.6",
     "solid-js": "^2.0.0-rc.6",
     "valibot": "^1.4.2"

--- a/solid-v2/fullstack-tanstack/pnpm-lock.yaml
+++ b/solid-v2/fullstack-tanstack/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^2.0.0-rc.6
         version: 2.0.0-rc.6(solid-js@2.0.0-rc.6)
       '@tanstack/solid-query':
-        specifier: ^6.0.0-rc.2
-        version: 6.0.0-rc.2(@solidjs/web@2.0.0-rc.6(solid-js@2.0.0-rc.6))(solid-js@2.0.0-rc.6)
+        specifier: ^6.0.0-rc.3
+        version: 6.0.0-rc.3(@solidjs/web@2.0.0-rc.6(solid-js@2.0.0-rc.6))(solid-js@2.0.0-rc.6)
       '@tanstack/solid-router':
         specifier: ^2.0.0-rc.6
         version: 2.0.0-rc.6(@solidjs/web@2.0.0-rc.6(solid-js@2.0.0-rc.6))(solid-js@2.0.0-rc.6)
@@ -861,8 +861,8 @@ packages:
     resolution: {integrity: sha512-hTWqJtqIFFdvuCl8WXNyrodp2L9zo2G37xKRrcVmVRWpAB2h+U1LuRAfS4tsFTiWOIoE/B+WDVFB8JpoEdw6jQ==}
     engines: {node: '>=20.19'}
 
-  '@tanstack/solid-query@6.0.0-rc.2':
-    resolution: {integrity: sha512-mg9FwI6z6EaU5MyFezxlYOQVQ0gHFKcPqpW7lHrodJsCP012ZXGGEzF3Y7KC1npVk3sPzhFsb5VsLMxe9UnCPA==}
+  '@tanstack/solid-query@6.0.0-rc.3':
+    resolution: {integrity: sha512-Wj23dMyRnVmKiYvvyMImZqb3+2Ftxc7FngUfloCAmQE2dpQO/QeqaSHNlpjbG6eoKqazVPe4k1xhxofUU+w/dA==}
     peerDependencies:
       '@solidjs/web': '>=2.0.0-rc.6 <3.0.0'
       solid-js: '>=2.0.0-rc.6 <3.0.0'
@@ -2751,7 +2751,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/solid-query@6.0.0-rc.2(@solidjs/web@2.0.0-rc.6(solid-js@2.0.0-rc.6))(solid-js@2.0.0-rc.6)':
+  '@tanstack/solid-query@6.0.0-rc.3(@solidjs/web@2.0.0-rc.6(solid-js@2.0.0-rc.6))(solid-js@2.0.0-rc.6)':
     dependencies:
       '@solidjs/web': 2.0.0-rc.6(solid-js@2.0.0-rc.6)
       '@tanstack/query-core': 5.101.4

--- a/solid-v2/fullstack-tanstack/pnpm-workspace.yaml
+++ b/solid-v2/fullstack-tanstack/pnpm-workspace.yaml
@@ -12,3 +12,4 @@ minimumReleaseAgeExclude:
   - solid-js
   - '@solidjs/*'
   - '@tanstack/solid-router@2.0.0-rc.5 || 2.0.0-rc.6'
+  - '@tanstack/solid-query@6.0.0-rc.3'

--- a/solid-v2/fullstack-tanstack/src/App.tsx
+++ b/solid-v2/fullstack-tanstack/src/App.tsx
@@ -1,6 +1,9 @@
+import { isServer } from '@solidjs/web';
+import * as serverFunctions from '@solidjs/web/server-functions';
 import { QueryClientProvider } from '@tanstack/solid-query';
 import { RouterProvider } from '@tanstack/solid-router';
 
+import { flightReporter } from './lib/flight';
 import { createQueryClient } from './lib/queries';
 import { createAppRouter } from './router';
 import './App.css';
@@ -16,6 +19,20 @@ import './App.css';
 // mutation call asks the server to fold refreshed data for that source into
 // its own response — see src/server-config.ts for the server half.)
 const queryClient = createQueryClient();
+
+// The report leg of scoped collection (src/lib/flight.ts): flight-eligible
+// mutation requests carry this cache's inventory and its active recipes, so
+// the server can skip recomputing what this client already holds and
+// re-execute declared queries no loader owns. Client-only — this module
+// also evaluates on the server (setup.tsx renders in App's place, but the
+// graph is shared), where in-process calls have no request to prepare and
+// the server entry ships no transport config. The namespace import keeps
+// the unused binding from being checked there.
+if (!isServer) {
+  serverFunctions.configureServerFunctionsClient({
+    prepareRequest: flightReporter(queryClient),
+  });
+}
 
 // No client boot pass: creating the router IS the hydration boot. The
 // server serialized each matched route's state into Solid's hydration

--- a/solid-v2/fullstack-tanstack/src/lib/flight.ts
+++ b/solid-v2/fullstack-tanstack/src/lib/flight.ts
@@ -1,0 +1,183 @@
+// Userland single-flight extension: key-scoped collection with a client
+// inventory and re-executable recipes. Everything here composes public
+// seams — no package patches.
+//
+// The base protocol (see src/server-config.ts) reruns the target page's
+// loaders on every mutation and ships the results. Correct, but blunt: it
+// recomputes data the client already holds, and it can't reach data no
+// loader owns (component-owned queries like the session). Declaring scope
+// on the mutation (`reload({ revalidate: 'users' })` → the X-Revalidate
+// header) sharpens both edges:
+//
+// - inventory (client → server): the mutation request carries the query
+//   hashes this client already caches. The collection gate skips
+//   recomputing them — the mutation's declaration is the license: anything
+//   it didn't name is fresh by its own testimony. Undeclared data the
+//   client DOESN'T hold still collects fully (new pages on redirects).
+// - recipes (client → server): queries declared through `serverQueryFn`
+//   are addressable — the server can re-execute `(fn.id, args)` via
+//   `getServerFunction` and fold the result into the same response. That
+//   covers declared data outside the loader graph (the session query) in
+//   the one round trip.
+// - the sweep (in @tanstack/solid-query): whatever a declared key matches
+//   beyond the payload is invalidated client-side — the safety net every
+//   failure mode here degrades onto (report too large, version skew,
+//   queries without recipes).
+//
+// Mutations that declare nothing keep today's behavior exactly.
+import { hashKey } from '@tanstack/solid-query';
+import { SINGLE_FLIGHT_HEADER } from '@solidjs/web/server-functions';
+import type { QueryClient, QueryKey } from '@tanstack/solid-query';
+
+/** Request header carrying the report; JSON, ASCII-escaped, capped. */
+const FLIGHT_REPORT_HEADER = 'X-Query-Flight';
+/** Past this the header is dropped whole — everything degrades to the sweep. */
+const REPORT_LIMIT = 4096;
+
+/** How to recompute a query remotely: a server function id + arguments. */
+interface FlightRecipe {
+  id: string;
+  args: Array<unknown>;
+}
+
+interface FlightReport {
+  /** Cached query hashes (the inventory — what this client holds). */
+  i: Array<string>;
+  /** Active addressable queries: `[queryKey, recipe]` pairs. */
+  r: Array<[QueryKey, FlightRecipe]>;
+}
+
+// ---------------------------------------------------------------- client --
+
+/**
+ * Declares a query's fetch as an addressable server-function call: builds
+ * the queryFn and stashes the `(id, args)` recipe in meta, one source of
+ * truth for both. Only recipe-declared queries can ride the flight from
+ * outside the loader graph; everything else falls back to the sweep.
+ */
+export function serverQueryFn<A extends Array<unknown>, R>(
+  fn: ((...args: A) => Promise<R>) & { readonly id: string },
+  ...args: A
+) {
+  return {
+    queryFn: () => fn(...args),
+    meta: { flight: { id: fn.id, args } satisfies FlightRecipe },
+  };
+}
+
+/**
+ * The report leg, as a `prepareRequest` hook (wire it in the client entry
+ * via `configureServerFunctionsClient`). On flight-eligible calls — the
+ * transport already stamped X-Single-Flight — it attaches the inventory
+ * and the active recipes. GET reads and non-flight calls are untouched.
+ */
+export function flightReporter(queryClient: QueryClient) {
+  return (init: RequestInit): RequestInit => {
+    if (!new Headers(init.headers).has(SINGLE_FLIGHT_HEADER)) return init;
+    const report: FlightReport = { i: [], r: [] };
+    for (const query of queryClient.getQueryCache().getAll()) {
+      if (query.state.status === 'success') report.i.push(query.queryHash);
+      const recipe = query.meta?.flight as FlightRecipe | undefined;
+      if (recipe && query.getObserversCount() > 0)
+        report.r.push([query.queryKey, recipe]);
+    }
+    // Header values are latin1: escape everything past printable ASCII
+    // (still valid JSON). Oversized reports are dropped whole rather than
+    // truncated — a partial report would misread as a partial cache.
+    const encoded = JSON.stringify(report).replace(
+      /[\u007f-\uffff]/g,
+      (c) => `\\u${c.charCodeAt(0).toString(16).padStart(4, '0')}`,
+    );
+    if (encoded.length > REPORT_LIMIT) return init;
+    return {
+      ...init,
+      headers: { ...(init.headers as Record<string, string>), [FLIGHT_REPORT_HEADER]: encoded },
+    };
+  };
+}
+
+// ---------------------------------------------------------------- server --
+
+/**
+ * Reads the mutation's report + declared keys into a collection plan:
+ * `skip` is the loader-prefetch gate, `recipes` the declared active
+ * instances to re-execute. Without declared keys there is no plan — the
+ * declaration is what licenses skipping — and collection stays full.
+ */
+export function planFlightCollection(
+  request: Request,
+  revalidateKeys: Array<string> | undefined,
+) {
+  let report: FlightReport | undefined;
+  try {
+    const raw = request.headers.get(FLIGHT_REPORT_HEADER);
+    if (raw) report = JSON.parse(raw) as FlightReport;
+  } catch {
+    // a malformed report is no report
+  }
+  const declared = (key: QueryKey) =>
+    revalidateKeys?.includes(String(key[0])) ?? false;
+  return {
+    /** Skip fetching what the client holds — unless the mutation declared it. */
+    skip: (key: QueryKey) =>
+      revalidateKeys !== undefined &&
+      report !== undefined &&
+      report.i.includes(hashKey(key)) &&
+      !declared(key),
+    /** Declared, active on the client, shaped like a recipe. */
+    recipes:
+      revalidateKeys && report
+        ? report.r.filter(
+            ([key, recipe]) =>
+              declared(key) &&
+              typeof recipe?.id === 'string' &&
+              Array.isArray(recipe.args),
+          )
+        : [],
+  };
+}
+
+// The gate rides the per-request QueryClient so `prefetch` (src/lib/
+// queries.ts) can consult it without threading arguments through loaders.
+const gates = new WeakMap<QueryClient, (key: QueryKey) => boolean>();
+
+export function setFlightGate(
+  queryClient: QueryClient,
+  skip: (key: QueryKey) => boolean,
+) {
+  gates.set(queryClient, skip);
+}
+
+export function flightGateSkips(queryClient: QueryClient, key: QueryKey) {
+  return gates.get(queryClient)?.(key) ?? false;
+}
+
+/**
+ * Re-executes declared active instances the loaders didn't produce and
+ * folds them into the collection client. `getServerFunction` resolves only
+ * registered functions (unknown ids — version skew — just skip: the sweep
+ * refetches), and each function does its own authorization, exactly as if
+ * the client had called it over RPC directly.
+ */
+export async function runFlightRecipes(
+  queryClient: QueryClient,
+  recipes: Array<[QueryKey, FlightRecipe]>,
+) {
+  if (recipes.length === 0) return;
+  const { getServerFunction } = await import(
+    '@solidjs/web/server-functions/server'
+  );
+  await Promise.all(
+    recipes.map(([queryKey, recipe]) => {
+      // Already collected (or being collected) by a loader: covered.
+      if (queryClient.getQueryCache().get(hashKey(queryKey))) return;
+      return queryClient
+        .prefetchQuery({
+          queryKey,
+          queryFn: () => getServerFunction(recipe.id)(...recipe.args),
+          retry: false,
+        })
+        .catch(() => undefined);
+    }),
+  );
+}

--- a/solid-v2/fullstack-tanstack/src/lib/queries.ts
+++ b/solid-v2/fullstack-tanstack/src/lib/queries.ts
@@ -6,6 +6,7 @@
 import type { FetchQueryOptions } from '@tanstack/solid-query';
 import { QueryClient, queryOptions } from '@tanstack/solid-query';
 
+import { flightGateSkips, serverQueryFn } from './flight';
 import { getCurrentUser, getUser, getUsers } from './users';
 
 export const usersQuery = () =>
@@ -14,8 +15,18 @@ export const usersQuery = () =>
 export const userQuery = (id: string) =>
   queryOptions({ queryKey: ['users', id], queryFn: () => getUser(id) });
 
+// The session read is component-owned: no route prefetches it, because it
+// is shell state every page shows rather than any page's data. That puts
+// it outside every loader — so this one query declares its fetch as a
+// recipe (`serverQueryFn`, src/lib/flight.ts): when a mutation names its
+// key (`reload({ revalidate: 'current-user' })`), the server re-executes
+// the call and ships the fresh session on the mutation's own response.
+// Loader-owned queries like the two above never need this — plain queryFn.
 export const currentUserQuery = () =>
-  queryOptions({ queryKey: ['current-user'], queryFn: () => getCurrentUser() });
+  queryOptions({
+    queryKey: ['current-user'],
+    ...serverQueryFn(getCurrentUser),
+  });
 
 // One factory for every side that needs a cache: the client boot
 // (src/App.tsx, one for the session), the per-request SSR setup
@@ -41,10 +52,14 @@ export function createQueryClient() {
 // of collapsing TTFB to the slowest fetch. No hydration exception: the
 // client never runs a boot load pass (createRouter primes matches from the
 // server's registry entries), so the first time a loader runs client-side
-// is a real navigation.
+// is a real navigation. During single-flight collection the gate
+// (src/lib/flight.ts) can answer that the mutation's client already holds
+// this query and didn't declare it stale — then the prefetch is skipped and
+// the response ships without it.
 export function prefetch(
   queryClient: QueryClient,
   options: FetchQueryOptions<any, any, any, any>,
 ) {
+  if (flightGateSkips(queryClient, options.queryKey)) return;
   void queryClient.prefetchQuery(options);
 }

--- a/solid-v2/fullstack-tanstack/src/lib/users.ts
+++ b/solid-v2/fullstack-tanstack/src/lib/users.ts
@@ -6,6 +6,7 @@
 // and are called through useMutation's `mutate` — the typical TanStack
 // shape. (The plain fullstack template shows the alternative: FormData
 // signatures + form `action` posts for no-JS progressive enhancement.)
+import { reload } from '@solidjs/web';
 import { GET } from '@solidjs/web/server-functions';
 
 import { findUser, listUsers, updateUser } from '../server/db';
@@ -36,15 +37,25 @@ export const getCurrentUser = GET(async () => {
   return user ? { id: userId!, ...user } : null;
 });
 
+// Mutations declare what they invalidate: `reload({ revalidate: key })`
+// stamps the key on the response (Solid's X-Revalidate header), and the
+// flight machinery scopes its work to it — the collection skips data the
+// caller already holds that no key names, re-executes declared queries the
+// loaders don't own (the session, on login/logout), and the client sweeps
+// whatever a key matches beyond the shipped payload. A mutation that
+// declares nothing keeps the unscoped behavior: rerun the page's loaders,
+// ship everything they produce.
 export async function login(id: string) {
   'use server';
   if (!findUser(id)) throw new Error(`No user "${id}"`);
   await setSession({ userId: id });
+  return reload({ revalidate: 'current-user' });
 }
 
 export async function logout() {
   'use server';
   await clearSession();
+  return reload({ revalidate: 'current-user' });
 }
 
 export async function renameUser(input: { id: string; name: string }) {
@@ -53,4 +64,5 @@ export async function renameUser(input: { id: string; name: string }) {
   // cosmetic; this check is the real gate.
   if (!(await getSession())?.userId) throw new Error('Sign in to rename users');
   updateUser(input.id, { name: input.name });
+  return reload({ revalidate: 'users' });
 }

--- a/solid-v2/fullstack-tanstack/src/routes/index.tsx
+++ b/solid-v2/fullstack-tanstack/src/routes/index.tsx
@@ -15,7 +15,6 @@ import logo from '../logo.svg';
 // (`prefetch` is hydration-boot aware — see src/lib/queries.ts.)
 export const Route = createFileRoute('/')({
   loader: ({ context }) => {
-    prefetch(context.queryClient, currentUserQuery());
     prefetch(context.queryClient, usersQuery());
   },
   head: () => ({ meta: [{ title: 'Home - Solid App' }] }),

--- a/solid-v2/fullstack-tanstack/src/routes/users.$id.tsx
+++ b/solid-v2/fullstack-tanstack/src/routes/users.$id.tsx
@@ -12,7 +12,6 @@ import { renameUser } from '../lib/users';
 export const Route = createFileRoute('/users/$id')({
   loader: ({ context, params }) => {
     prefetch(context.queryClient, userQuery(params.id));
-    prefetch(context.queryClient, currentUserQuery());
   },
   head: ({ params }) => ({
     meta: [{ title: `User ${params.id} - Solid App` }],

--- a/solid-v2/fullstack-tanstack/src/server-config.ts
+++ b/solid-v2/fullstack-tanstack/src/server-config.ts
@@ -20,6 +20,11 @@ import { registerFlightDataSource } from '@solidjs/web/server-functions/server';
 import { FLIGHT_DATA_SOURCE, dehydrateSettled } from '@tanstack/solid-query';
 import { loadFlightTarget } from '@tanstack/solid-router/ssr/server';
 
+import {
+  planFlightCollection,
+  runFlightRecipes,
+  setFlightGate,
+} from './lib/flight';
 import { createQueryClient } from './lib/queries';
 import { createAppRouter } from './router';
 
@@ -29,14 +34,28 @@ registerFlightDataSource(FLIGHT_DATA_SOURCE, (event, outcome) => {
   // src/setup.tsx, minus the render. (`loadFlightTarget` resolves undefined
   // when there is no target — a non-browser caller, or a redirect leaving
   // the app.)
+  //
+  // When the mutation declared its scope (`reload({ revalidate })`), the
+  // plan (src/lib/flight.ts) scopes that collection: the gate skips loader
+  // prefetches for data the caller already holds that no declared key
+  // names, and the recipes re-execute declared queries the loaders don't
+  // own. Undeclared mutations get an empty plan — full collection, exactly
+  // the sequence above.
   const queryClient = createQueryClient();
+  const plan = planFlightCollection(outcome.request, outcome.revalidateKeys);
+  setFlightGate(queryClient, plan.skip);
   return loadFlightTarget({
     router: createAppRouter(queryClient),
     event,
     outcome,
     async collect() {
+      await runFlightRecipes(queryClient, plan.recipes);
       const state = await dehydrateSettled(queryClient);
-      return state.queries.length > 0 ? state : undefined;
+      // With keys declared, an empty slice still ships: delivering it is
+      // what hands the response to the client-side sweep.
+      return state.queries.length > 0 || outcome.revalidateKeys
+        ? state
+        : undefined;
     },
   });
 });


### PR DESCRIPTION
Updates `@tanstack/solid-query` to 6.0.0-rc.3 (which ships the single-flight X-Revalidate sweep, TanStack/query#11394) and builds the scoped-collection pattern on top of it.

Mutations now declare their invalidation scope with Solid's existing response helper — `reload({ revalidate: 'users' })` — and `src/lib/flight.ts` composes the rest from public seams (~90 lines of code, no package patches):

- **Inventory**: flight-eligible mutation requests carry the client cache's query hashes (`X-Query-Flight`, stamped by a `prepareRequest` hook). The server's collection gate skips rerunning loader prefetches for data the caller already holds that no declared key names — the mutation's declaration is the license.
- **Recipes**: a query no loader owns can declare its fetch as an addressable server-function call (`serverQueryFn`). When a mutation names its key, the server re-executes the call — under the mutation's folded cookie effects — and ships the result on the same response. The template's session query (`current-user`) is the demo: it's component-owned shell state, no route prefetches it, and login/logout reach it purely through its declared key.
- **The sweep** (rc.3, in the adapter): whatever a declared key matches beyond the shipped payload is invalidated client-side — the safety net every failure mode degrades onto (oversized report, version skew, queries without recipes).

Loader-owned queries keep their textbook shape (`queryFn: () => getUsers()` — no new API), and mutations that declare nothing keep today's unscoped behavior exactly: rerun the target page's loaders, ship everything.

Verified against the production build with headless Playwright (18 wire-level assertions): login ships the recipe-executed session while the inventory gate keeps the client-held users list off the wire; rename reships the declared users data (sidebar updates from the same flight) while gating the session; zero follow-up refetches after any mutation; clean hydration throughout. Template unit tests and typecheck green.

— Claude via Cursor, at Ryan's direction

Made with [Cursor](https://cursor.com)