### PR TITLE
fullstack-tanstack: update @tanstack/solid-router to 2.0.0-rc.7

### DIFF
--- a/solid-v2/fullstack-tanstack/package.json
+++ b/solid-v2/fullstack-tanstack/package.json
@@ -31,7 +31,7 @@
     "@remix-run/cookie": "^0.5.4",
     "@solidjs/web": "^2.0.0-rc.6",
     "@tanstack/solid-query": "^6.0.0-rc.3",
-    "@tanstack/solid-router": "^2.0.0-rc.6",
+    "@tanstack/solid-router": "^2.0.0-rc.7",
     "solid-js": "^2.0.0-rc.6",
     "valibot": "^1.4.2"
   }

--- a/solid-v2/fullstack-tanstack/pnpm-lock.yaml
+++ b/solid-v2/fullstack-tanstack/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^6.0.0-rc.3
         version: 6.0.0-rc.3(@solidjs/web@2.0.0-rc.6(solid-js@2.0.0-rc.6))(solid-js@2.0.0-rc.6)
       '@tanstack/solid-router':
-        specifier: ^2.0.0-rc.6
-        version: 2.0.0-rc.6(@solidjs/web@2.0.0-rc.6(solid-js@2.0.0-rc.6))(solid-js@2.0.0-rc.6)
+        specifier: ^2.0.0-rc.7
+        version: 2.0.0-rc.7(@solidjs/web@2.0.0-rc.6(solid-js@2.0.0-rc.6))(solid-js@2.0.0-rc.6)
       solid-js:
         specifier: ^2.0.0-rc.6
         version: 2.0.0-rc.6
@@ -867,8 +867,8 @@ packages:
       '@solidjs/web': '>=2.0.0-rc.6 <3.0.0'
       solid-js: '>=2.0.0-rc.6 <3.0.0'
 
-  '@tanstack/solid-router@2.0.0-rc.6':
-    resolution: {integrity: sha512-ahTyk3ObuVQtcRFlWbDxe6glsz3KByYoqAYv4iWsLjmiXL+lw2fAuc67dOPQc6nt8AoOKIRy+/VLsMITw+GN8A==}
+  '@tanstack/solid-router@2.0.0-rc.7':
+    resolution: {integrity: sha512-B8Ehz2n2qjUKFmh/jGV5UUrDm6qe49ziG4TGnrsEpBbARsiNq2MhNHzCIHCjSn7j7k1Qh5W8EdrJP8fJFyCOmw==}
     engines: {node: '>=20.19'}
     peerDependencies:
       '@solidjs/web': '>=2.0.0-0 <3.0.0'
@@ -2757,7 +2757,7 @@ snapshots:
       '@tanstack/query-core': 5.101.4
       solid-js: 2.0.0-rc.6
 
-  '@tanstack/solid-router@2.0.0-rc.6(@solidjs/web@2.0.0-rc.6(solid-js@2.0.0-rc.6))(solid-js@2.0.0-rc.6)':
+  '@tanstack/solid-router@2.0.0-rc.7(@solidjs/web@2.0.0-rc.6(solid-js@2.0.0-rc.6))(solid-js@2.0.0-rc.6)':
     dependencies:
       '@solid-devtools/logger': 0.9.11(solid-js@2.0.0-rc.6)
       '@solid-primitives/refs': 1.1.4(solid-js@2.0.0-rc.6)

--- a/solid-v2/fullstack-tanstack/pnpm-workspace.yaml
+++ b/solid-v2/fullstack-tanstack/pnpm-workspace.yaml
@@ -11,5 +11,5 @@
 minimumReleaseAgeExclude:
   - solid-js
   - '@solidjs/*'
-  - '@tanstack/solid-router@2.0.0-rc.5 || 2.0.0-rc.6'
+  - '@tanstack/solid-router@2.0.0-rc.7'
   - '@tanstack/solid-query@6.0.0-rc.3'


### PR DESCRIPTION
Bumps `@tanstack/solid-router` from 2.0.0-rc.6 to 2.0.0-rc.7 in `solid-v2/fullstack-tanstack`.

## Why

On rc.6, `vite dev` answered every page with a 500:

```
TypeError: Cannot read properties of undefined (reading 'matches')
    at primeRouterFromRegistry (@tanstack/solid-router/src/registryTransfer.ts:92)
    at new Router (@tanstack/solid-router/src/router.ts:114)
    at createRouter (src/router.tsx)
```

Under Vite's `development` export condition, `@tanstack/router-core/isServer` resolves to `undefined` on both the server and the client. rc.6 tested it with plain truthiness, so the server-side router ran the client-only registry priming (the crash above), and `RouterProvider` never serialized match state into the hydration registry. rc.7 falls back to the router's own `isServer` (`isServer ?? router.isServer`), which derives from `typeof document` when the flag is undefined.

Production builds were unaffected: the `node` condition exports `true`.

The `minimumReleaseAge` exclusion in `pnpm-workspace.yaml` moves to the new floor. rc.7 and rc.6 have identical dependency ranges, so the lockfile change is the one package.

## Verified

- `pnpm install` resolves rc.7 through the workspace exclusion alone (no `--config` override).
- `tsc --noEmit`, `oxlint`, `vitest run` (10 tests), and `vite build` all pass.
- `vite dev` on rc.7: `/` and `/users/1` answer 200, `/nope` answers 404, and the SSR HTML carries the `tsr:` registry entries for every matched route. Hydration issues no loader fetches; client navigation, sign-in, and the single-flight rename each make exactly one `/_server` call with no console errors.
- The same checkout on rc.6 reproduces the 500 on every page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
