### PR TITLE
solid-v2/with-tanstack-router: repin @tanstack/solid-router to 2.0.0-rc.7

### DIFF
--- a/solid-v2/with-tanstack-router/package.json
+++ b/solid-v2/with-tanstack-router/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@solidjs/web": "^2.0.0-rc.6",
-    "@tanstack/solid-router": "^2.0.0-rc.6",
+    "@tanstack/solid-router": "^2.0.0-rc.7",
     "solid-js": "^2.0.0-rc.6"
   }
 }

--- a/solid-v2/with-tanstack-router/pnpm-lock.yaml
+++ b/solid-v2/with-tanstack-router/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^2.0.0-rc.6
         version: 2.0.0-rc.6(solid-js@2.0.0-rc.6)
       '@tanstack/solid-router':
-        specifier: ^2.0.0-rc.6
-        version: 2.0.0-rc.6(@solidjs/web@2.0.0-rc.6(solid-js@2.0.0-rc.6))(solid-js@2.0.0-rc.6)
+        specifier: ^2.0.0-rc.7
+        version: 2.0.0-rc.7(@solidjs/web@2.0.0-rc.6(solid-js@2.0.0-rc.6))(solid-js@2.0.0-rc.6)
       solid-js:
         specifier: ^2.0.0-rc.6
         version: 2.0.0-rc.6
@@ -686,8 +686,8 @@ packages:
     resolution: {integrity: sha512-hTWqJtqIFFdvuCl8WXNyrodp2L9zo2G37xKRrcVmVRWpAB2h+U1LuRAfS4tsFTiWOIoE/B+WDVFB8JpoEdw6jQ==}
     engines: {node: '>=20.19'}
 
-  '@tanstack/solid-router@2.0.0-rc.6':
-    resolution: {integrity: sha512-ahTyk3ObuVQtcRFlWbDxe6glsz3KByYoqAYv4iWsLjmiXL+lw2fAuc67dOPQc6nt8AoOKIRy+/VLsMITw+GN8A==}
+  '@tanstack/solid-router@2.0.0-rc.7':
+    resolution: {integrity: sha512-B8Ehz2n2qjUKFmh/jGV5UUrDm6qe49ziG4TGnrsEpBbARsiNq2MhNHzCIHCjSn7j7k1Qh5W8EdrJP8fJFyCOmw==}
     engines: {node: '>=20.19'}
     peerDependencies:
       '@solidjs/web': '>=2.0.0-0 <3.0.0'
@@ -2377,7 +2377,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/solid-router@2.0.0-rc.6(@solidjs/web@2.0.0-rc.6(solid-js@2.0.0-rc.6))(solid-js@2.0.0-rc.6)':
+  '@tanstack/solid-router@2.0.0-rc.7(@solidjs/web@2.0.0-rc.6(solid-js@2.0.0-rc.6))(solid-js@2.0.0-rc.6)':
     dependencies:
       '@solid-devtools/logger': 0.9.11(solid-js@2.0.0-rc.6)
       '@solid-primitives/refs': 1.1.4(solid-js@2.0.0-rc.6)

--- a/solid-v2/with-tanstack-router/pnpm-workspace.yaml
+++ b/solid-v2/with-tanstack-router/pnpm-workspace.yaml
@@ -11,4 +11,4 @@
 minimumReleaseAgeExclude:
   - solid-js
   - '@solidjs/*'
-  - '@tanstack/solid-router@2.0.0-rc.5 || 2.0.0-rc.6'
+  - '@tanstack/solid-router@2.0.0-rc.7'


### PR DESCRIPTION
Follows [#300](https://github.com/solidjs/templates/pull/300), which moved `fullstack-tanstack` to rc.7 but not its client-only sibling. The previous two floors (rc.5 → `7b7285e`, rc.6 → `f57c905`) each had this companion repin; rc.7 didn't.

rc.7 fixes `@tanstack/router-core`'s `isServer` resolving to `undefined` under Vite's `development` export condition (#299). This template is client-mode only, so it never hit the SSR 500, but the two TanStack templates should track the same router floor, and the `minimumReleaseAgeExclude` entry (`rc.5 || rc.6`) was otherwise going to keep a fresh `pnpm install` on rc.6 regardless of the caret range.

- `@tanstack/solid-router` `^2.0.0-rc.6` → `^2.0.0-rc.7`
- `pnpm-workspace.yaml` exclusion moves to the new floor
- Lockfile: one package (rc.7 and rc.6 have identical dependency ranges)

Verified: `tsc --noEmit`, `oxlint`, `vitest run`, and `vite build` (including the `dist/client/index.html` prerender) all pass.

Note: `pnpm-lock.yaml` will touch different lines than [#302](https://github.com/solidjs/templates/pull/302); whichever lands second may need a lockfile refresh.

Made with [Cursor](https://cursor.com)