### PR TITLE
solid-v2/fullstack, fullstack-tanstack: server.js rejects the [...404] route chunk; check path containment instead of ".."

### DIFF
--- a/solid-v2/fullstack-tanstack/server.js
+++ b/solid-v2/fullstack-tanstack/server.js
@@ -14,6 +14,7 @@ import { handleRequest } from './dist/server/server.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const port = process.env.PORT || 3000;
+const clientDir = path.join(__dirname, 'dist', 'client');
 
 const MIME = {
   '.js': 'application/javascript',
@@ -23,6 +24,24 @@ const MIME = {
   '.ico': 'image/x-icon',
   '.svg': 'image/svg+xml',
 };
+
+// The file under dist/client a request path maps to, or undefined when it
+// resolves outside that directory. Containment is decided on the resolved
+// path, not by rejecting any `..` in the URL: that substring test also
+// refuses legitimate assets — the chunk a catch-all route `[...404].tsx`
+// builds to is `assets/_...404_-<hash>.js`, and turning it away sends a
+// request for JavaScript to the SSR handler, which answers with the 404
+// page's HTML and leaves that page un-hydrated.
+function clientAssetPath(url) {
+  let pathname;
+  try {
+    pathname = decodeURIComponent(url.split('?')[0]);
+  } catch {
+    return; // Malformed percent-encoding can't name a file we have.
+  }
+  const file = path.join(clientDir, pathname);
+  return file.startsWith(clientDir + path.sep) ? file : undefined;
+}
 
 function webRequest(req, res) {
   const url = new URL(req.url || '/', `http://${req.headers.host || `localhost:${port}`}`);
@@ -102,10 +121,11 @@ const server = createServer(async (req, res) => {
   const url = req.url || '/';
 
   // Static client assets first.
-  if (url !== '/' && !url.includes('..')) {
+  const file = url === '/' ? undefined : clientAssetPath(url);
+  if (file) {
     try {
-      const content = readFileSync(path.resolve(__dirname, 'dist/client' + url.split('?')[0]));
-      res.setHeader('Content-Type', MIME[path.extname(url)] || 'application/octet-stream');
+      const content = readFileSync(file);
+      res.setHeader('Content-Type', MIME[path.extname(file)] || 'application/octet-stream');
       res.end(content);
       return;
     } catch {

--- a/solid-v2/fullstack/server.js
+++ b/solid-v2/fullstack/server.js
@@ -14,6 +14,7 @@ import { handleRequest } from './dist/server/server.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const port = process.env.PORT || 3000;
+const clientDir = path.join(__dirname, 'dist', 'client');
 
 const MIME = {
   '.js': 'application/javascript',
@@ -23,6 +24,24 @@ const MIME = {
   '.ico': 'image/x-icon',
   '.svg': 'image/svg+xml',
 };
+
+// The file under dist/client a request path maps to, or undefined when it
+// resolves outside that directory. Containment is decided on the resolved
+// path, not by rejecting any `..` in the URL: that substring test also
+// refuses legitimate assets — the chunk a catch-all route `[...404].tsx`
+// builds to is `assets/_...404_-<hash>.js`, and turning it away sends a
+// request for JavaScript to the SSR handler, which answers with the 404
+// page's HTML and leaves that page un-hydrated.
+function clientAssetPath(url) {
+  let pathname;
+  try {
+    pathname = decodeURIComponent(url.split('?')[0]);
+  } catch {
+    return; // Malformed percent-encoding can't name a file we have.
+  }
+  const file = path.join(clientDir, pathname);
+  return file.startsWith(clientDir + path.sep) ? file : undefined;
+}
 
 function webRequest(req, res) {
   const url = new URL(req.url || '/', `http://${req.headers.host || `localhost:${port}`}`);
@@ -102,10 +121,11 @@ const server = createServer(async (req, res) => {
   const url = req.url || '/';
 
   // Static client assets first.
-  if (url !== '/' && !url.includes('..')) {
+  const file = url === '/' ? undefined : clientAssetPath(url);
+  if (file) {
     try {
-      const content = readFileSync(path.resolve(__dirname, 'dist/client' + url.split('?')[0]));
-      res.setHeader('Content-Type', MIME[path.extname(url)] || 'application/octet-stream');
+      const content = readFileSync(file);
+      res.setHeader('Content-Type', MIME[path.extname(file)] || 'application/octet-stream');
       res.end(content);
       return;
     } catch {


### PR DESCRIPTION
`server.js` in both fullstack templates guards static asset serving with `!url.includes('..')`. A catch-all route `src/routes/[...404].tsx` builds to `dist/client/assets/_...404_-<hash>.js` (Vite's chunk-name sanitizing turns the brackets into `_` and keeps the dots), so the chunk's URL contains `..`, the request falls through to `handleRequest`, and the SSR handler answers a request for JavaScript with the 404 page's HTML. The module preload fails and the 404 page hydrates dead under `node server.js`. `vite preview` is unaffected.

Reproduced 2026-09-10 with solid-js 2.0.0-rc.6, @solidjs/router 2.0.0-next.21, @solidjs/vite-plugin 3.0.0-next.38 (`vite build`, then `pnpm start`):

| request | before | after |
|---|---|---|
| `GET /assets/_...404_-DdAS84x5.js` | `404 text/html` | `200 application/javascript` |
| `GET /assets/index-CbEfGLRp.js?v=1` | `200 application/octet-stream` | `200 application/javascript` |
| `GET /../server/server.js`, `/%2e%2e/%2e%2e/package.json`, `/assets/..%2f..%2f..%2fpackage.json`, `/%`, `/assets/%00.js` | SSR 404 page | SSR 404 page |

The fix maps the decoded pathname onto `dist/client` with `path.join` and serves only when the resolved path starts with `<clientDir>/`; misses still fall through to `handleRequest`. The MIME type now comes from the resolved file instead of the raw URL, which is what fixed the query-string row. Both `server.js` copies stay byte-identical (`fullstack-tanstack` has no catch-all route file, but it shares the guard). No README text describes the guard, so no docs change.

Verified in both templates: `vitest run` green (10 each), `vite build` clean, prod servers boot. In a browser against the fullstack prod server, `/some-missing-page` preloads the `_...404_` chunk (200) and the 404 page hydrates: clicking Home is a client-side navigation (a `window` marker set on the 404 page survives it) and the Counter increments.

**Fragility note:** the `..` in the chunk name comes from Vite's default chunk-name sanitizing of the route file name `[...404].tsx` (brackets → `_`, dots kept) in the build @solidjs/vite-plugin drives (Vite 8 / rolldown). Any static host, CDN rule, or hand-written server with a "reject `..` in the path" guard refuses that chunk the same way. A sanitizer that also collapsed runs of dots would remove the whole class of problem upstream; that is probably worth an issue on the plugin or Vite, not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
